### PR TITLE
Fix audit blockers: source-tag posts, multi-post upsert, hash collisions

### DIFF
--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -97,7 +97,7 @@ function zoneFor(platform: Platform) {
   return platform;
 }
 
-function coordFor(platform: Platform, externalId: string) {
+function coordFor(platform: Platform, externalId: string, publishedAt: Date) {
   const zoneCenters: Partial<Record<Platform, { x: number; y: number }>> = {
     X: { x: 30, y: 45 },
     LINKEDIN: { x: 70, y: 45 },
@@ -111,8 +111,9 @@ function coordFor(platform: Platform, externalId: string) {
     PERSONAL_SITE: { x: 54, y: 54 },
   };
   const center = zoneCenters[platform] ?? { x: 50, y: 50 };
+  const seed = `${externalId}:${platform}:${publishedAt.toISOString().slice(0, 10)}`;
   let hash = 0;
-  for (let i = 0; i < externalId.length; i++) hash = (hash * 33 + externalId.charCodeAt(i)) >>> 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash * 33 + seed.charCodeAt(i)) >>> 0;
   return {
     x: Math.max(6, Math.min(94, center.x + ((hash % 17) - 8))),
     y: Math.max(8, Math.min(92, center.y + (((hash >> 8) % 13) - 6))),
@@ -190,26 +191,30 @@ export async function persistActivities({
 
     const metrics = metricsFromActivity(activity);
     const scores = scoresFromMetrics(metrics);
-    const { x, y } = coordFor(surface.platform, externalId);
-    const existing = await db.post.findFirst({
+    const { x, y } = coordFor(surface.platform, externalId, publishedAt);
+    const sourceId = `acquired:${provider.toLowerCase()}`;
+    const existing = await db.post.findMany({
       where: { OR: [{ rawActivityId: raw.id }, { surfaceId, externalId }] },
       select: { id: true },
     });
 
-    if (existing) {
-      await db.post.update({
-        where: { id: existing.id },
-        data: {
-          text,
-          permalink: activity.permalink,
-          acquiredVia: provider,
-          acquiredAt: new Date(),
-          rawActivityId: raw.id,
-          metrics: { upsert: { create: metrics, update: metrics } },
-          scores: { upsert: { create: scores, update: scores } },
-        },
-      });
-      updated += 1;
+    if (existing.length > 0) {
+      for (const post of existing) {
+        await db.post.update({
+          where: { id: post.id },
+          data: {
+            text,
+            permalink: activity.permalink,
+            acquiredVia: provider,
+            acquiredAt: new Date(),
+            rawActivityId: raw.id,
+            sourceId,
+            metrics: { upsert: { create: metrics, update: metrics } },
+            scores: { upsert: { create: scores, update: scores } },
+          },
+        });
+      }
+      updated += existing.length;
     } else {
       await db.post.create({
         data: {
@@ -220,6 +225,7 @@ export async function persistActivities({
           rawActivityId: raw.id,
           acquiredVia: provider,
           acquiredAt: new Date(),
+          sourceId,
           text,
           platform: surface.platform,
           contentType: contentTypeFor(surface.platform, text),

--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -193,28 +193,31 @@ export async function persistActivities({
     const scores = scoresFromMetrics(metrics);
     const { x, y } = coordFor(surface.platform, externalId, publishedAt);
     const sourceId = `acquired:${provider.toLowerCase()}`;
+    const acquiredAt = new Date();
     const existing = await db.post.findMany({
       where: { OR: [{ rawActivityId: raw.id }, { surfaceId, externalId }] },
       select: { id: true },
     });
 
     if (existing.length > 0) {
-      for (const post of existing) {
-        await db.post.update({
-          where: { id: post.id },
-          data: {
-            text,
-            permalink: activity.permalink,
-            acquiredVia: provider,
-            acquiredAt: new Date(),
-            rawActivityId: raw.id,
-            sourceId,
-            metrics: { upsert: { create: metrics, update: metrics } },
-            scores: { upsert: { create: scores, update: scores } },
-          },
-        });
-      }
-      updated += existing.length;
+      await Promise.all(
+        existing.map((post) =>
+          db.post.update({
+            where: { id: post.id },
+            data: {
+              text,
+              permalink: activity.permalink,
+              acquiredVia: provider,
+              acquiredAt,
+              rawActivityId: raw.id,
+              sourceId,
+              metrics: { upsert: { create: metrics, update: metrics } },
+              scores: { upsert: { create: scores, update: scores } },
+            },
+          }),
+        ),
+      );
+      updated += 1;
     } else {
       await db.post.create({
         data: {
@@ -224,7 +227,7 @@ export async function persistActivities({
           permalink: activity.permalink,
           rawActivityId: raw.id,
           acquiredVia: provider,
-          acquiredAt: new Date(),
+          acquiredAt,
           sourceId,
           text,
           platform: surface.platform,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,6 +177,7 @@ model Post {
   rawActivity        RawActivity?    @relation(fields: [rawActivityId], references: [id])
   acquiredVia        AcquisitionProvider?
   acquiredAt         DateTime?
+  sourceId           String?
   metrics            PostMetrics?
   scores             PostScores?
   rippleEvents       RippleEvent[]
@@ -190,6 +191,7 @@ model Post {
   @@index([surfaceId, publishedAt])
   @@index([rawActivityId])
   @@index([surfaceId, externalId])
+  @@index([sourceId])
   @@index([campaign])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -640,6 +640,7 @@ async function main() {
             advancedZone: advancedZoneFor(platform, shotType),
             confidence: shotType === "three_pointer_promo" ? "NEEDS_INTERNAL_ANALYTICS" : "MODELED",
             recommendedPlayId: playFor(platform, shotType, analytics.employeeId),
+            sourceId: "seeded:roster-fixture",
             metrics: { create: metrics },
             scores: { create: scores },
           },


### PR DESCRIPTION
Stacks on top of #1. Addresses the three blocking findings from the Phase 1+2 audit so PR #1 can merge.

## Fixes

**#1 — CRITICAL: Synthetic seed posts were unmarked.** Seeded engagement metrics looked identical to acquired data, so an operator viewing e.g. Austin's "12 consulting leads" couldn't tell whether it was real acquisition or fixture filler. Adds `Post.sourceId` (nullable, indexed). `prisma/seed.ts` tags every seeded post `"seeded:roster-fixture"`; `lib/acquisition/persist.ts` tags acquired posts `"acquired:<provider>"`. Future UI work can read this to show provenance.

**#2 — HIGH: Multi-Post-per-RawActivity upsert was broken.** Schema allows multiple `Post` rows per `RawActivity` (e.g. a Twitter thread root + replies). The previous `findFirst` only updated one Post on re-runs, leaving siblings with stale metrics — which would have double-counted or missed updates in aggregation. Switched to `findMany` and updated every match.

**#3 — Coord hash collisions.** `coordFor` hashed only `externalId`, so a re-published URL always landed on the same court coordinate. Hash now seeds on `externalId:platform:YYYY-MM-DD` so re-publishes disambiguate.

## Migration note

This adds a column (`Post.sourceId`) and an index. Run `pnpm exec prisma db push` (or generate a migration) on each environment before deploying. The column is nullable, so existing rows are unaffected; the seed script populates it on next run.

## Test plan

- [x] `pnpm exec prisma validate`
- [x] `pnpm exec prisma generate`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Re-seed locally and confirm `select count(*) from "Post" where "sourceId" = 'seeded:roster-fixture'` matches expected post count
- [x] Run an acquisition job twice on a multi-post thread and confirm all child posts get updated metrics on the second run

## Notes

- Audit issue #3 (coord hash) was flagged as cosmetic. Bundled here since the fix is one line and the audit recommended it.
- No UI surface change for the seeded marker yet — exposing it in `PlayerCard` is a follow-up so reviewers can decide how prominently to flag fixture data.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Rd3z9Gg4XAX8Uf8bw2Dec)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keeganmoody33/every-court-vision/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
