### PR TITLE
Phase 1.5: hardening + dedup fixes (post-merge follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 .DS_Store
 .playwright-mcp
 desktop-overview.png
+.claude/

--- a/app/api/acquisition/run/route.ts
+++ b/app/api/acquisition/run/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { Platform } from "@prisma/client";
+import { z } from "zod";
 
 import { runAcquisitionForSurface } from "@/lib/acquisition/router";
 import { db } from "@/lib/db";
@@ -6,20 +8,36 @@ import { db } from "@/lib/db";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const runRequestSchema = z
+  .object({
+    surfaceId: z.string().optional(),
+    employeeId: z.string().optional(),
+    platform: z.nativeEnum(Platform).optional(),
+    windowDays: z.number().int().min(1).max(365).optional(),
+  })
+  // Reject empty bodies. Without this, the endpoint runs acquisition for up to 24
+  // arbitrary surfaces — uncontrolled fan-out + upstream API quota burn.
+  .refine((value) => Boolean(value.surfaceId || value.employeeId || value.platform), {
+    message: "Provide at least one of surfaceId, employeeId, or platform.",
+  });
+
 export async function POST(request: Request) {
-  const body = (await request.json().catch(() => ({}))) as {
-    surfaceId?: string;
-    employeeId?: string;
-    platform?: string;
-    windowDays?: number;
-  };
+  const raw = await request.json().catch(() => ({}));
+  const parsed = runRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: "invalid_request", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const body = parsed.data;
 
   const surfaces = body.surfaceId
     ? await db.surface.findMany({ where: { id: body.surfaceId } })
     : await db.surface.findMany({
         where: {
           employeeId: body.employeeId,
-          platform: body.platform as never,
+          platform: body.platform,
           present: true,
         },
         take: 24,
@@ -29,6 +47,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: "no_surfaces_found" }, { status: 404 });
   }
 
+  // TODO(phase-4): Replace sequential loop with concurrency-limited parallelism (e.g.,
+  // p-limit with concurrency=4) once live providers are wired. Naive Promise.all hits
+  // upstream rate limits; pure sequential will timeout on Vercel at scale. Sequential
+  // is fine today because most providers return `disabled` instantly until tokens land.
   const results = [];
   for (const surface of surfaces) {
     results.push(await runAcquisitionForSurface(surface.id, body.windowDays ?? 90));

--- a/components/AcquisitionTable.tsx
+++ b/components/AcquisitionTable.tsx
@@ -86,7 +86,8 @@ export function AcquisitionTable({ rows }: { rows: AcquisitionSurfaceRow[] }) {
                 <TableCell className="text-right font-semibold text-white">{row.postCount}</TableCell>
                 <TableCell className="text-right font-semibold text-white">{row.rawActivityCount}</TableCell>
                 <TableCell className="min-w-[150px] text-xs text-muted-foreground">
-                  {row.lastRunAt ? new Date(row.lastRunAt).toLocaleString() : "Not run"}
+                  {/* ISO format avoids server/client locale hydration mismatch in Next 16. */}
+                  {row.lastRunAt ? new Date(row.lastRunAt).toISOString().replace("T", " ").slice(0, 19) : "Not run"}
                   {row.lastProvider ? <div className="mt-1 text-white">{row.lastProvider}</div> : null}
                 </TableCell>
                 <TableCell>

--- a/components/PlayerCard.tsx
+++ b/components/PlayerCard.tsx
@@ -1,12 +1,18 @@
 import { ArrowUpRight } from "lucide-react";
 
 import { ProgressLine } from "@/components/ProgressLine";
+import { SyntheticPill } from "@/components/SyntheticPill";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Employee, EmployeeWithSurfaces } from "@/lib/types";
 
 export function PlayerCard({ employee }: { employee: Employee | EmployeeWithSurfaces }) {
   const postCount = "postCount" in employee ? employee.postCount : undefined;
   const pendingPosts = postCount === 0;
+  // While Phase 4 acquisition is unwired, every seeded post has no sourceId.
+  // Show the pill on any card with seeded data so viewers know the metrics are
+  // preview-grade. Cards with `pendingPosts` already render a "Data Readiness"
+  // panel and don't need an additional pill.
+  const showSyntheticPill = postCount !== undefined && postCount > 0;
 
   return (
     <Card className="border-white/10 bg-white/[0.045]">
@@ -16,6 +22,11 @@ export function PlayerCard({ employee }: { employee: Employee | EmployeeWithSurf
             <p className="stat-label">{employee.role}</p>
             <CardTitle className="mt-1 text-2xl">{employee.name}</CardTitle>
             <p className="mt-1 text-sm text-primary">{employee.archetype}</p>
+            {showSyntheticPill ? (
+              <div className="mt-2">
+                <SyntheticPill compact />
+              </div>
+            ) : null}
           </div>
           <ArrowUpRight className="size-5 text-primary" />
         </div>

--- a/components/SidePanel.tsx
+++ b/components/SidePanel.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, CircleDot, ExternalLink } from "lucide-react";
 
 import { AttributionBadge } from "@/components/AttributionBadge";
 import { RippleGraph } from "@/components/RippleGraph";
+import { SyntheticPill, isSyntheticPost } from "@/components/SyntheticPill";
 import {
   Sheet,
   SheetContent,
@@ -47,9 +48,15 @@ export function SidePanel({
                 <span className="rounded-full border border-white/10 px-2.5 py-0.5 text-xs text-muted-foreground">
                   {shotOutcome(post, scoringMode)}
                 </span>
+                {isSyntheticPost(post) ? <SyntheticPill compact /> : null}
               </div>
               <SheetTitle>{post.platform} Film Clip</SheetTitle>
               <SheetDescription>{employee?.name} - {formatShortDate(post.timestamp)}</SheetDescription>
+              {isSyntheticPost(post) ? (
+                <div className="mt-3">
+                  <SyntheticPill />
+                </div>
+              ) : null}
             </SheetHeader>
 
             <div className="mt-6 space-y-5">

--- a/components/SyntheticPill.tsx
+++ b/components/SyntheticPill.tsx
@@ -1,0 +1,48 @@
+import { Sparkles } from "lucide-react";
+
+/**
+ * Honest disclosure that a post or aggregate is preview-grade synthetic data, not
+ * real engagement. Triggers when `Post.sourceId` is null/empty (no acquisition has
+ * tagged this row yet) — i.e., it's a seed fixture. Real scraped posts get
+ * `sourceId = "acquired:<provider>"` from `lib/acquisition/persist.ts` and the
+ * pill clears.
+ *
+ * Usage:
+ *   {isSyntheticPost(post) ? <SyntheticPill /> : null}
+ *   {isSyntheticPost(post) ? <SyntheticPill compact /> : null}
+ */
+export function SyntheticPill({ compact = false }: { compact?: boolean }) {
+  if (compact) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full border border-orange-300/40 bg-orange-300/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-orange-200"
+        title="Preview data. Body text and engagement numbers are placeholders. Real values land when Phase 4 acquisition runs against this surface."
+      >
+        <Sparkles className="size-2.5" />
+        Preview
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-orange-300/40 bg-orange-300/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-wider text-orange-200"
+      title="Preview data. Body text and engagement numbers are placeholders. Real values land when Phase 4 acquisition runs against this surface."
+    >
+      <Sparkles className="size-3" />
+      Synthetic preview · awaiting first scrape
+    </span>
+  );
+}
+
+/**
+ * Single source of truth for "is this post still preview data?" Used by every
+ * consumer that wants to gate the pill — keeps the rule consistent across pages.
+ *
+ * The acquisition layer (lib/acquisition/persist.ts) tags real scrapes as
+ * `acquired:<provider>`; everything else (seed fixtures with `seeded:roster-fixture`,
+ * null, manual entry) renders the pill.
+ */
+export function isSyntheticPost(post: { sourceId?: string | null }): boolean {
+  return !post.sourceId || !post.sourceId.startsWith("acquired:");
+}

--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -91,10 +91,18 @@ function contentTypeFor(platform: Platform, text: string) {
 }
 
 function zoneFor(platform: Platform) {
+  // Display-format zone names. Must stay in sync with prisma/seed.ts:zoneFor and the
+  // basicZones table in lib/constants.ts. Returning the raw Prisma enum here (e.g.,
+  // "LINKEDIN") would break zone grouping on Shot Zones, Court Heat, and Players.
+  if (platform === "LINKEDIN") return "LinkedIn";
+  if (platform === "GITHUB") return "GitHub";
+  if (platform === "INSTAGRAM") return "Instagram";
+  if (platform === "NEWSLETTER" || platform === "SUBSTACK") return "Newsletter";
   if (platform === "YOUTUBE" || platform === "PODCAST") return "YouTube/Podcast";
   if (platform === "TEAMMATE_AMPLIFICATION") return "Teammate Amplification";
   if (platform === "EXTERNAL_AMPLIFICATION") return "External Amplification";
-  return platform;
+  if (platform === "LAUNCHES" || platform === "PRODUCT_HUNT") return "Launches";
+  return "X";
 }
 
 function coordFor(platform: Platform, externalId: string, publishedAt: Date) {
@@ -142,6 +150,13 @@ export async function persistActivities({
   let skipped = 0;
 
   for (const [index, activity] of activities.entries()) {
+    // Manual imports accept untyped JSON, so defend against malformed rows here.
+    // Without this guard, `null.trim()` aborts the entire job and leaves it stuck
+    // in RUNNING because the post-loop status update never runs.
+    if (typeof activity?.text !== "string") {
+      skipped += 1;
+      continue;
+    }
     const text = activity.text.trim();
     if (!text) {
       skipped += 1;

--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -197,6 +197,7 @@ export async function persistActivities({
     const existing = await db.post.findMany({
       where: { OR: [{ rawActivityId: raw.id }, { surfaceId, externalId }] },
       select: { id: true },
+      orderBy: { createdAt: "asc" },
     });
 
     if (existing.length > 0) {
@@ -204,10 +205,16 @@ export async function persistActivities({
 
       if (duplicates.length > 0) {
         const duplicateIds = duplicates.map((p) => p.id);
-        await db.postMetrics.deleteMany({ where: { postId: { in: duplicateIds } } });
-        await db.postScores.deleteMany({ where: { postId: { in: duplicateIds } } });
-        await db.rippleEvent.deleteMany({ where: { rootPostId: { in: duplicateIds } } });
-        await db.post.deleteMany({ where: { id: { in: duplicateIds } } });
+        await db.$transaction(async (tx) => {
+          await tx.postMetrics.deleteMany({ where: { postId: { in: duplicateIds } } });
+          await tx.postScores.deleteMany({ where: { postId: { in: duplicateIds } } });
+          await tx.rippleEvent.updateMany({
+            where: { parentId: { in: duplicateIds } },
+            data: { parentId: null },
+          });
+          await tx.rippleEvent.deleteMany({ where: { rootPostId: { in: duplicateIds } } });
+          await tx.post.deleteMany({ where: { id: { in: duplicateIds } } });
+        });
       }
 
       await db.post.update({

--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -208,28 +208,37 @@ export async function persistActivities({
         await db.$transaction(async (tx) => {
           await tx.postMetrics.deleteMany({ where: { postId: { in: duplicateIds } } });
           await tx.postScores.deleteMany({ where: { postId: { in: duplicateIds } } });
-          await tx.rippleEvent.updateMany({
-            where: { parentId: { in: duplicateIds } },
-            data: { parentId: null },
-          });
           await tx.rippleEvent.deleteMany({ where: { rootPostId: { in: duplicateIds } } });
           await tx.post.deleteMany({ where: { id: { in: duplicateIds } } });
+          await tx.post.update({
+            where: { id: canonical.id },
+            data: {
+              text,
+              permalink: activity.permalink,
+              acquiredVia: provider,
+              acquiredAt,
+              rawActivityId: raw.id,
+              sourceId,
+              metrics: { upsert: { create: metrics, update: metrics } },
+              scores: { upsert: { create: scores, update: scores } },
+            },
+          });
+        });
+      } else {
+        await db.post.update({
+          where: { id: canonical.id },
+          data: {
+            text,
+            permalink: activity.permalink,
+            acquiredVia: provider,
+            acquiredAt,
+            rawActivityId: raw.id,
+            sourceId,
+            metrics: { upsert: { create: metrics, update: metrics } },
+            scores: { upsert: { create: scores, update: scores } },
+          },
         });
       }
-
-      await db.post.update({
-        where: { id: canonical.id },
-        data: {
-          text,
-          permalink: activity.permalink,
-          acquiredVia: provider,
-          acquiredAt,
-          rawActivityId: raw.id,
-          sourceId,
-          metrics: { upsert: { create: metrics, update: metrics } },
-          scores: { upsert: { create: scores, update: scores } },
-        },
-      });
       updated += 1;
     } else {
       await db.post.create({

--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -208,7 +208,10 @@ export async function persistActivities({
         await db.$transaction(async (tx) => {
           await tx.postMetrics.deleteMany({ where: { postId: { in: duplicateIds } } });
           await tx.postScores.deleteMany({ where: { postId: { in: duplicateIds } } });
-          await tx.rippleEvent.deleteMany({ where: { rootPostId: { in: duplicateIds } } });
+          await tx.rippleEvent.updateMany({
+            where: { rootPostId: { in: duplicateIds } },
+            data: { rootPostId: canonical.id },
+          });
           await tx.post.deleteMany({ where: { id: { in: duplicateIds } } });
           await tx.post.update({
             where: { id: canonical.id },

--- a/lib/acquisition/persist.ts
+++ b/lib/acquisition/persist.ts
@@ -200,23 +200,29 @@ export async function persistActivities({
     });
 
     if (existing.length > 0) {
-      await Promise.all(
-        existing.map((post) =>
-          db.post.update({
-            where: { id: post.id },
-            data: {
-              text,
-              permalink: activity.permalink,
-              acquiredVia: provider,
-              acquiredAt,
-              rawActivityId: raw.id,
-              sourceId,
-              metrics: { upsert: { create: metrics, update: metrics } },
-              scores: { upsert: { create: scores, update: scores } },
-            },
-          }),
-        ),
-      );
+      const [canonical, ...duplicates] = existing;
+
+      if (duplicates.length > 0) {
+        const duplicateIds = duplicates.map((p) => p.id);
+        await db.postMetrics.deleteMany({ where: { postId: { in: duplicateIds } } });
+        await db.postScores.deleteMany({ where: { postId: { in: duplicateIds } } });
+        await db.rippleEvent.deleteMany({ where: { rootPostId: { in: duplicateIds } } });
+        await db.post.deleteMany({ where: { id: { in: duplicateIds } } });
+      }
+
+      await db.post.update({
+        where: { id: canonical.id },
+        data: {
+          text,
+          permalink: activity.permalink,
+          acquiredVia: provider,
+          acquiredAt,
+          rawActivityId: raw.id,
+          sourceId,
+          metrics: { upsert: { create: metrics, update: metrics } },
+          scores: { upsert: { create: scores, update: scores } },
+        },
+      });
       updated += 1;
     } else {
       await db.post.create({

--- a/lib/acquisition/providers/spider.ts
+++ b/lib/acquisition/providers/spider.ts
@@ -6,6 +6,20 @@ import type { ProviderAdapter } from "@/lib/acquisition/types";
 export const spiderProvider: ProviderAdapter = {
   provider: AcquisitionProvider.SPIDER,
   async collect({ surface }) {
+    // D12 runtime fence: Spider must never touch LinkedIn. The policy table omits
+    // SPIDER from the LinkedIn route chain, but a future bug or a misconfigured
+    // surface could route here. Refuse declaratively.
+    if (
+      surface.platform === "LINKEDIN" ||
+      surface.url?.toLowerCase().includes("linkedin.com")
+    ) {
+      return {
+        status: "failed",
+        activities: [],
+        failureCode: "compliance_violation",
+        failureReason: "Spider is not permitted for LinkedIn surfaces (D12).",
+      };
+    }
     if (!env.SPIDER_API_KEY) {
       return {
         status: "disabled",

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -72,7 +72,9 @@ const sourceReadinessFromDb: Record<string, DataSource["readiness"]> = {
   FUTURE: "Future",
 };
 
-const emptyMetrics: PostMetrics = {
+// Frozen so accidental mutation by a downstream consumer can't poison the fallback
+// for all subsequent posts.
+const emptyMetrics: PostMetrics = Object.freeze({
   views: 0,
   reach: 0,
   likes: 0,
@@ -88,9 +90,9 @@ const emptyMetrics: PostMetrics = {
   consultingLeads: 0,
   revenue: 0,
   assistedConversions: 0,
-};
+}) as PostMetrics;
 
-const emptyScores: PostScores = {
+const emptyScores: PostScores = Object.freeze({
   awareness: 0,
   engagement: 0,
   trust: 0,
@@ -105,7 +107,7 @@ const emptyScores: PostScores = {
   assistRate: 0,
   trustGravity: 0,
   humanHalo: 0,
-};
+}) as PostScores;
 
 function getParam(searchParams: SearchParamsLike, key: keyof FilterState) {
   if (!searchParams) return undefined;
@@ -241,6 +243,7 @@ function mapPost(post: {
   zone: string;
   advancedZone: string;
   confidence: string;
+  sourceId?: string | null;
   recommendedPlayId: string | null;
   metrics: (PostMetrics & { id?: string; postId?: string }) | null;
   scores: (PostScores & { id?: string; postId?: string }) | null;
@@ -264,6 +267,7 @@ function mapPost(post: {
     zone: post.zone,
     advancedZone: post.advancedZone,
     confidence: confidenceFromDb[post.confidence] ?? "Estimated",
+    sourceId: post.sourceId ?? null,
     metrics: post.metrics ?? emptyMetrics,
     scores: post.scores ?? emptyScores,
     recommendedPlayId: post.recommendedPlayId ?? "play-soft-cta",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -181,6 +181,12 @@ export interface Post {
   zone: string;
   advancedZone: string;
   confidence: MetricConfidence;
+  /**
+   * Provenance tag. `null` or `seed:*` = preview/fixture data (synthetic engagement).
+   * `acquired:<provider>` = real scrape (e.g., `acquired:x_api`). The SyntheticPill
+   * UI surfaces this so the viewer doesn't mistake fixture metrics for real ones.
+   */
+  sourceId?: string | null;
   metrics: PostMetrics;
   scores: PostScores;
   recommendedPlayId: string;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+/// <reference types="next/types/global" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Follow-up PR landing the work that accumulated on `phase-1-data-layer` after PR #1 merged.

## Summary
- **Dedup correctness** (PRs #3, #4 from devin/fix-duplicate-posts-dedup + devin/fix-devin-review-flags): persist.ts now does transactional findMany + dedup. When findMany returns multiple posts for one activity, keeps the canonical (oldest by createdAt) and deletes the rest with their PostMetrics, PostScores, and RippleEvents.
- **Phase 1.5 hardening** (this commit): D12 Spider LinkedIn fence, next-env.d.ts CI fix, Zod validation on /api/acquisition/run, activity.text guard before .trim(), persist.ts zoneFor display strings, AcquisitionTable ISO date (Next 16 hydration), Object.freeze on empty singletons.
- **Synthetic-data tell**: new `components/SyntheticPill.tsx` with `isSyntheticPost()` helper that triggers when `Post.sourceId` is not `acquired:*`. Wired into PlayerCard (compact) and SidePanel (header + description). Austin won't mistake fixture metrics for real engagement.

## Scope
This is the credibility-and-correctness layer on top of the original Phase 1+2 PR #1.

## Test plan
- [ ] `pnpm typecheck` (local hangs on FS issue — relying on remote check + Devin Review)
- [ ] `pnpm build` clean
- [ ] `rg "isSyntheticPost\|sourceId" components lib` shows the pill wiring
- [ ] Visit `/players` and `/shot-plot` — Kate Lee newsletter posts show "Synthetic preview" pill
- [ ] `POST /api/acquisition/run {}` returns 400 (empty body rejected)
- [ ] `POST /api/acquisition/run {"surfaceId":"<linkedin-surface>"}` with SPIDER as fallback returns FAILED with `compliance_violation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keeganmoody33/every-court-vision/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
