### PR TITLE
brand: editorial publication wrap (#007) — Every-style essays + chalk telestrator + hex.tech figures

### DIFF
--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -23,7 +23,13 @@ export async function GET(request: Request) {
   const agent = url.searchParams.get("agent")?.trim() || "Bobbito";
   const figure = url.searchParams.get("figure")?.trim() ?? null;
   const referer = request.headers.get("referer");
-  const back = referer && referer.startsWith(url.origin) ? referer : "/overview";
+  // Strict origin equality: prefix-matching is open-redirect-vulnerable
+  // (`origin.startsWith("https://example.com")` matches `https://example.com.evil.com/...`).
+  // The referer is only honored if it's exactly the origin or a path on the origin.
+  const back =
+    referer && (referer === url.origin || referer.startsWith(url.origin + "/"))
+      ? referer
+      : "/overview";
 
   const wantsJson =
     request.headers.get("accept")?.toLowerCase().includes("application/json") ?? false;

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -131,6 +131,23 @@ export async function GET(request: Request) {
   );
 }
 
+/**
+ * Validate a Referer header against the current origin before echoing it into the
+ * response HTML. A naive `startsWith(origin)` check is vulnerable to open redirect
+ * because `https://example.com.evil.com` starts with `https://example.com`. Parse
+ * the URL and compare origins strictly.
+ */
+function safeBackLink(referer: string | null, origin: string): string {
+  if (!referer) return "/overview";
+  try {
+    const parsed = new URL(referer);
+    if (parsed.origin === origin) return parsed.pathname + parsed.search + parsed.hash;
+  } catch {
+    // fallthrough
+  }
+  return "/overview";
+}
+
 function escapeHtml(input: string): string {
   return input
     .replace(/&/g, "&amp;")

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/agent
+ *
+ * Stub handler for the "Read with [agent]" CTA that lives on every figure in the
+ * editorial publication wrap. Until the real agent (Bobbito) is wired up to the
+ * data narrative pipeline, this route returns a tiny on-brand HTML page so the
+ * CTA is interactive — not a 404 dead-end.
+ *
+ * Returns JSON when the client sends `Accept: application/json` (so future
+ * client-side fetch flows can poll/render in-line) and HTML otherwise so a
+ * direct anchor click lands somewhere readable.
+ *
+ * Replace with the real agent integration in the brand-wrap plan's Phase 4 work.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const prompt = url.searchParams.get("prompt")?.trim() ?? "";
+  const agent = url.searchParams.get("agent")?.trim() || "Bobbito";
+  const figure = url.searchParams.get("figure")?.trim() ?? null;
+  const referer = request.headers.get("referer");
+  const back = referer && referer.startsWith(url.origin) ? referer : "/overview";
+
+  const wantsJson =
+    request.headers.get("accept")?.toLowerCase().includes("application/json") ?? false;
+
+  if (wantsJson) {
+    return NextResponse.json(
+      {
+        ok: true,
+        status: "queued",
+        agent,
+        figure,
+        prompt,
+        message:
+          prompt.length > 0
+            ? `${agent} is on the bench — your figure prompt is queued for the next briefing.`
+            : `${agent} is on the bench — wire a prompt to a figure to get a real reading.`,
+        requestId: crypto.randomUUID(),
+      },
+      { status: 202, headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  const safePrompt = escapeHtml(prompt);
+  const safeAgent = escapeHtml(agent);
+  const safeBack = escapeHtml(back);
+
+  return new NextResponse(
+    `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>${safeAgent} is on the bench · Every Court Vision</title>
+<style>
+  :root { color-scheme: dark; }
+  body {
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    background: #0d0a07;
+    color: #f4efe6;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    padding: 2rem;
+    background-image:
+      radial-gradient(ellipse 80rem 40rem at 18% -10%, rgba(255,193,102,0.05), transparent 60%),
+      radial-gradient(ellipse 60rem 36rem at 88% 12%, rgba(102,180,230,0.04), transparent 65%);
+  }
+  main { max-width: 38rem; }
+  .eyebrow {
+    font-family: ui-monospace, "SFMono-Regular", monospace;
+    font-size: .6875rem;
+    letter-spacing: .22em;
+    text-transform: uppercase;
+    color: #ff9d42;
+    font-variant-numeric: tabular-nums;
+  }
+  h1 {
+    font-family: "Iowan Old Style", Georgia, serif;
+    font-size: clamp(2rem, 4vw + .5rem, 3rem);
+    line-height: 1.04;
+    letter-spacing: -.025em;
+    margin: .75rem 0 1rem;
+  }
+  p { font-family: "Iowan Old Style", Georgia, serif; font-size: 1.0625rem; line-height: 1.68; color: rgba(244,239,230,.88); }
+  blockquote {
+    margin: 1.5rem 0; padding: 1rem 1.25rem;
+    border-left: 2px solid #7b5bc9;
+    background: rgba(255,255,255,.02);
+    font-family: "Iowan Old Style", Georgia, serif; font-style: italic;
+  }
+  a {
+    color: #2bcaa6; text-decoration: underline; text-underline-offset: 3px;
+    font-family: ui-monospace, monospace; font-size: .8125rem;
+    letter-spacing: .04em; text-transform: uppercase;
+  }
+  .rule { height:1px; width: 3rem; background: rgba(244,239,230,.3); margin: 1.25rem 0; }
+</style>
+</head>
+<body>
+<main>
+  <p class="eyebrow">Every Court Vision · Stub Agent</p>
+  <h1>${safeAgent} is on the bench.</h1>
+  <p>The named analyst that lives in every <em>Read with ${safeAgent}</em> CTA isn&rsquo;t wired up yet — Phase 4 of the brand-wrap plan reconnects this route to the real data-narrative pipeline.</p>
+  ${
+    safePrompt
+      ? `<blockquote>The prompt this figure would have sent: &ldquo;${safePrompt}&rdquo;</blockquote>`
+      : `<p>No prompt was supplied — once the agent ships, every figure passes a contextual question into this handler.</p>`
+  }
+  <div class="rule"></div>
+  <a href="${safeBack}">← Back to the briefing</a>
+</main>
+</body>
+</html>`,
+    {
+      status: 202,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    },
+  );
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -22,14 +22,7 @@ export async function GET(request: Request) {
   const prompt = url.searchParams.get("prompt")?.trim() ?? "";
   const agent = url.searchParams.get("agent")?.trim() || "Bobbito";
   const figure = url.searchParams.get("figure")?.trim() ?? null;
-  const referer = request.headers.get("referer");
-  // Strict origin equality: prefix-matching is open-redirect-vulnerable
-  // (`origin.startsWith("https://example.com")` matches `https://example.com.evil.com/...`).
-  // The referer is only honored if it's exactly the origin or a path on the origin.
-  const back =
-    referer && (referer === url.origin || referer.startsWith(url.origin + "/"))
-      ? referer
-      : "/overview";
+  const back = safeBackLink(request.headers.get("referer"), url.origin);
 
   const wantsJson =
     request.headers.get("accept")?.toLowerCase().includes("application/json") ?? false;

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,7 @@
  * operating mode; NBA Street Vol. 2 GameBreakers are the celebration layer; hex.tech
  * informs the data-figure rhythm. Default mode is dark — Court Vision is a film room.
  *
- * Cited verbatim from /Users/keeganmoody/every-lab/graph/themes/every-design-system.md:
+ * Cited verbatim from the every-lab graph (graph/themes/every-design-system.md):
  *   "Generous whitespace with modular sections, horizontal rules for separation" (line 54)
  *   "High-contrast black-on-white and white-on-black themes" (line 47)
  *   "Provenance Rail: Left-side UI component using color (green/purple) to track text origin" (line 254)

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,26 +2,98 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Every Court Vision — design tokens.
+ *
+ * Aesthetic spine: every.to is the editorial spine; ESPN broadcast grammar is the
+ * operating mode; NBA Street Vol. 2 GameBreakers are the celebration layer; hex.tech
+ * informs the data-figure rhythm. Default mode is dark — Court Vision is a film room.
+ *
+ * Cited verbatim from /Users/keeganmoody/every-lab/graph/themes/every-design-system.md:
+ *   "Generous whitespace with modular sections, horizontal rules for separation" (line 54)
+ *   "High-contrast black-on-white and white-on-black themes" (line 47)
+ *   "Provenance Rail: Left-side UI component using color (green/purple) to track text origin" (line 254)
+ */
+
 @layer base {
   :root {
-    --background: 222 28% 6%;
-    --foreground: 210 30% 96%;
-    --card: 222 25% 9%;
-    --card-foreground: 210 30% 96%;
-    --popover: 222 25% 9%;
-    --popover-foreground: 210 30% 96%;
-    --primary: 176 76% 58%;
-    --primary-foreground: 220 32% 6%;
-    --secondary: 224 20% 16%;
-    --secondary-foreground: 210 30% 96%;
-    --muted: 224 18% 15%;
-    --muted-foreground: 215 14% 66%;
-    --accent: 221 22% 18%;
-    --accent-foreground: 210 30% 96%;
-    --destructive: 354 94% 67%;
-    --border: 222 18% 22%;
-    --input: 222 18% 22%;
-    --ring: 176 76% 58%;
+    /* Editorial dark — the film room at midnight. */
+    --background: 28 14% 5%;          /* #0d0a07 — warm ink */
+    --foreground: 38 38% 93%;         /* #f4efe6 — warm cream */
+
+    --card: 28 14% 7%;                /* slightly lifted */
+    --card-foreground: 38 38% 93%;
+
+    --popover: 28 16% 9%;
+    --popover-foreground: 38 38% 93%;
+
+    /* Primary: Spiral-leaning editorial green-teal. Used as link / action accent. */
+    --primary: 169 65% 48%;           /* ~#2bcaa6 */
+    --primary-foreground: 28 22% 6%;
+
+    --secondary: 30 10% 14%;
+    --secondary-foreground: 38 38% 93%;
+
+    --muted: 30 8% 12%;
+    --muted-foreground: 36 12% 62%;
+
+    --accent: 30 12% 18%;
+    --accent-foreground: 38 38% 93%;
+
+    --destructive: 354 78% 60%;       /* #ff5a66 — Court Vision miss red */
+    --border: 30 14% 16%;
+    --input: 30 14% 16%;
+    --ring: 169 65% 48%;
+
+    /* Editorial paper — warm off-white surface used for "essay" panels inside the dark room */
+    --paper: 38 36% 96%;              /* #f7f3ea */
+    --paper-foreground: 28 22% 8%;
+    --paper-rule: 28 12% 78%;
+
+    /* Proof-style provenance rails. Quote: "Provenance Rail: Left-side UI component using color
+       (green/purple) to track text origin" — every-design-system.md:254 */
+    --confidence-direct: 142 64% 34%;     /* #1f8a4f */
+    --confidence-strong: 148 49% 47%;     /* #3fae6f */
+    --confidence-inferred: 261 47% 57%;   /* #7b5bc9 */
+    --confidence-needs: 36 70% 51%;       /* #d89a2c */
+    --confidence-neutral: 0 0% 42%;
+
+    /* Court palette — basketball canvas. Sacred. Do not use in chrome. */
+    --court-line: 36 79% 80%;
+    --court-wood: 18 36% 13%;
+    --court-paint: 220 41% 16%;
+    --court-teal: 169 78% 58%;
+    --court-orange: 27 100% 63%;
+    --court-purple: 263 100% 78%;
+    --court-red: 354 100% 68%;
+    --court-blue: 213 100% 67%;
+
+    /* Halftime lights — atmospheric glows. */
+    --halftime-warm: 36 100% 60%;
+    --halftime-cool: 196 90% 60%;
+  }
+
+  .light,
+  [data-theme="paper"] {
+    /* Every-publication paper mode — used for essay surfaces nested inside the room. */
+    --background: 38 36% 96%;
+    --foreground: 28 22% 8%;
+    --card: 0 0% 100%;
+    --card-foreground: 28 22% 8%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 28 22% 8%;
+    --primary: 169 78% 22%;
+    --primary-foreground: 38 36% 96%;
+    --secondary: 38 24% 90%;
+    --secondary-foreground: 28 22% 8%;
+    --muted: 38 24% 92%;
+    --muted-foreground: 28 12% 38%;
+    --accent: 38 28% 86%;
+    --accent-foreground: 28 22% 8%;
+    --destructive: 354 78% 46%;
+    --border: 28 12% 78%;
+    --input: 28 12% 82%;
+    --ring: 169 78% 22%;
   }
 
   * {
@@ -29,25 +101,177 @@
   }
 
   html {
-    background: #05070d;
+    background: hsl(var(--background));
     color-scheme: dark;
+    font-feature-settings: "ss01", "cv11", "ss03";
   }
 
   body {
     @apply bg-background text-foreground antialiased;
+    /* Atmospheric halftime lights. Very low opacity — never compete with content. */
     background:
-      radial-gradient(circle at top left, rgba(62, 231, 211, 0.08), transparent 34rem),
-      radial-gradient(circle at 70% 10%, rgba(255, 157, 66, 0.07), transparent 30rem),
-      linear-gradient(135deg, #05070d 0%, #080b12 42%, #0d1018 100%);
+      radial-gradient(ellipse 80rem 40rem at 18% -10%, hsl(var(--halftime-warm) / 0.045), transparent 60%),
+      radial-gradient(ellipse 60rem 36rem at 88% 12%, hsl(var(--halftime-cool) / 0.04), transparent 65%),
+      radial-gradient(circle at 50% 110%, hsl(var(--court-purple) / 0.05), transparent 55%),
+      hsl(var(--background));
+    font-family: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  }
+
+  /* Editorial body — Fraunces with the SOFT axis pushed up for warmth, opsz auto.
+     The serif lives where prose lives: essay containers, figure captions, pull quotes. */
+  .prose-essay {
+    font-family: var(--font-fraunces), "Iowan Old Style", Georgia, serif;
+    font-feature-settings: "liga", "kern", "ss01";
+    font-variation-settings: "SOFT" 60, "WONK" 0, "opsz" 144;
+  }
+
+  /* Tabular numerals everywhere stats live. */
+  .tabular {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
   }
 }
 
 @layer components {
   .stat-label {
-    @apply text-xs font-medium uppercase tracking-normal text-muted-foreground;
+    @apply font-mono text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground tabular;
   }
 
   .glass-panel {
-    @apply rounded-lg border border-white/10 bg-white/[0.045] shadow-[0_20px_70px_rgba(0,0,0,0.25)] backdrop-blur;
+    @apply rounded-md border border-white/10 bg-white/[0.02] shadow-[0_30px_120px_-40px_rgba(0,0,0,0.6)] backdrop-blur-sm;
+  }
+
+  /* Editorial paper surface — Every essay container nested inside the film-room canvas. */
+  .paper {
+    background: hsl(var(--paper));
+    color: hsl(var(--paper-foreground));
+    border: 1px solid hsl(var(--paper-rule) / 0.4);
+    box-shadow:
+      0 1px 0 hsl(var(--paper-rule) / 0.5),
+      0 40px 120px -30px rgba(0, 0, 0, 0.55),
+      0 8px 30px -10px rgba(0, 0, 0, 0.4);
+  }
+
+  .paper a {
+    color: hsl(169 78% 22%);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  /* Horizontal rule treatment — a single fine line, the way an Every essay separates sections.
+     Quote: "Generous whitespace with modular sections, horizontal rules for separation" — line 54. */
+  .rule {
+    @apply h-px w-full bg-foreground/15;
+  }
+  .paper .rule {
+    background: hsl(var(--paper-rule) / 0.55);
+  }
+
+  /* ESPN ticker — the scoreboard strip used in CompanyHeader and Figure tickers. */
+  .ticker {
+    @apply font-mono text-xs uppercase tracking-[0.22em] tabular;
+  }
+
+  /* Chalk — the telestrator annotation type and stroke style. */
+  .chalk {
+    font-family: var(--font-chalk), "Marker Felt", cursive;
+    color: hsl(var(--court-line));
+  }
+
+  .chalk-stroke {
+    stroke: hsl(var(--court-line) / 0.85);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 3 6;
+    filter: drop-shadow(0 0 0.6px rgba(255, 255, 255, 0.35));
+  }
+
+  /* GameBreaker — NBA Street display. ONLY used in celebration overlays. */
+  .gamebreaker {
+    font-family: var(--font-gamebreaker), Impact, sans-serif;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-style: italic;
+  }
+
+  /* Drop cap — first letter of an essay's lede paragraph (Every essay convention). */
+  .drop-cap::first-letter {
+    font-family: var(--font-fraunces), Georgia, serif;
+    font-weight: 600;
+    font-size: 4.6em;
+    line-height: 0.85;
+    float: left;
+    padding: 0.18em 0.12em 0 0;
+    color: hsl(var(--primary));
+    font-variation-settings: "SOFT" 100, "opsz" 144;
+  }
+  .paper .drop-cap::first-letter {
+    color: hsl(169 78% 22%);
+  }
+
+  /* Underline reveal for CTAs ("Read with Bobbito"). */
+  .reveal-underline {
+    background-image: linear-gradient(currentColor, currentColor);
+    background-size: 0% 1px;
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    transition: background-size 280ms cubic-bezier(0.2, 0.7, 0.1, 1);
+  }
+  .reveal-underline:hover,
+  .reveal-underline:focus-visible {
+    background-size: 100% 1px;
+  }
+}
+
+@layer utilities {
+  /* Draw-in animation for chalk strokes. Used by telestrator paths via inline style. */
+  @keyframes draw-in {
+    from { stroke-dashoffset: var(--length, 200); }
+    to   { stroke-dashoffset: 0; }
+  }
+  .animate-draw-in {
+    stroke-dasharray: var(--length, 200);
+    stroke-dashoffset: var(--length, 200);
+    animation: draw-in 1.4s cubic-bezier(0.65, 0, 0.35, 1) forwards;
+  }
+
+  /* Slow drift used for halftime lights / ambient surfaces. */
+  @keyframes drift {
+    0%, 100% { transform: translate3d(0, 0, 0); }
+    50%      { transform: translate3d(0, -6px, 0); }
+  }
+  .animate-drift {
+    animation: drift 9s ease-in-out infinite;
+  }
+
+  /* Holographic shimmer — GameBreaker accent. */
+  @keyframes hologram {
+    0%   { background-position: 0% 50%; }
+    100% { background-position: 200% 50%; }
+  }
+  .holographic {
+    background: linear-gradient(
+      120deg,
+      hsl(var(--court-teal)) 0%,
+      hsl(var(--court-purple)) 25%,
+      hsl(var(--court-orange)) 50%,
+      hsl(var(--court-purple)) 75%,
+      hsl(var(--court-teal)) 100%
+    );
+    background-size: 200% 100%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: hologram 3.4s linear infinite;
+  }
+
+  /* Count-up reveal for stats — used by Figure on tile mount. */
+  @keyframes count-rise {
+    from { opacity: 0; transform: translateY(8%); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .animate-count {
+    animation: count-rise 700ms cubic-bezier(0.2, 0.7, 0.1, 1) both;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Anton, Fraunces, Geist, Geist_Mono, Permanent_Marker } from "next/font/google";
 import { Suspense } from "react";
 
 import { AppShell } from "@/components/AppShell";
@@ -17,9 +17,31 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  axes: ["SOFT", "WONK", "opsz"],
+  display: "swap",
+});
+
+const permanentMarker = Permanent_Marker({
+  variable: "--font-chalk",
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+});
+
+const anton = Anton({
+  variable: "--font-gamebreaker",
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+});
+
 export const metadata: Metadata = {
-  title: "Every Court Vision",
-  description: "A film-room growth analytics dashboard for Every.",
+  title: "Every Court Vision · #007",
+  description:
+    "A film-room reading of Every's distributed publishing. Not a leaderboard — a way to see the shape of the growth you already create.",
 };
 
 export default function RootLayout({
@@ -29,9 +51,17 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} ${fraunces.variable} ${permanentMarker.variable} ${anton.variable}`}
+      >
         <TooltipProvider delayDuration={120}>
-          <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading court...</div>}>
+          <Suspense
+            fallback={
+              <div className="px-8 py-10 font-mono text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                Tipping off…
+              </div>
+            }
+          >
             <AppShell>{children}</AppShell>
           </Suspense>
         </TooltipProvider>

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -1,15 +1,35 @@
-import { MousePointerClick, Radio, Sparkles, Target, Users, WalletCards } from "lucide-react";
-
-import { InsightCard } from "@/components/InsightCard";
-import { MetricCard } from "@/components/MetricCard";
-import { OverviewCharts } from "@/components/OverviewCharts";
+import { CourtTelestrator } from "@/components/CourtTelestrator";
+import {
+  Body,
+  Byline,
+  Cover,
+  Essay,
+  Eyebrow,
+  Figure,
+  FourTierFeedback,
+  Lede,
+  Pull,
+  Section,
+  StatTile,
+  TLDR,
+} from "@/components/essay";
+import { OverviewFigures } from "@/components/OverviewFigures";
 import { PlatformCard } from "@/components/PlatformCard";
-import { platformCards, sumMetrics } from "@/lib/aggregations";
-import { formatCurrency, formatNumber } from "@/lib/formatters";
-import { employeeMapFromRoster, filtersFromSearchParams, getPosts, getRoster } from "@/lib/queries";
+import { groupPosts, platformCards, sumMetrics } from "@/lib/aggregations";
+import { formatCurrency, formatNumber, formatPercent } from "@/lib/formatters";
+import {
+  employeeMapFromRoster,
+  filtersFromSearchParams,
+  getPosts,
+  getRippleEvents,
+  getRoster,
+} from "@/lib/queries";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const today = () =>
+  new Intl.DateTimeFormat("en", { month: "long", day: "numeric", year: "numeric" }).format(new Date());
 
 export default async function OverviewPage({
   searchParams,
@@ -17,41 +37,266 @@ export default async function OverviewPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const filters = filtersFromSearchParams(await searchParams);
-  const [roster, filtered] = await Promise.all([getRoster(), getPosts(filters)]);
+  const [roster, filtered, ripples] = await Promise.all([
+    getRoster(),
+    getPosts(filters),
+    getRippleEvents(filters),
+  ]);
   const metrics = sumMetrics(filtered);
   const cards = platformCards(filtered);
   const employeeMap = employeeMapFromRoster(roster);
 
+  // Derived narrative — the data the agent (Bobbito) reads to write the briefing.
+  const byPlatform = groupPosts(filtered, (post) => post.platform);
+  const byEmployee = groupPosts(filtered, (post) => post.employeeId);
+
+  const platformBySignups = Object.entries(byPlatform)
+    .map(([platform, posts]) => ({ platform, signups: sumMetrics(posts).signups }))
+    .sort((a, b) => b.signups - a.signups);
+
+  const platformByReach = Object.entries(byPlatform)
+    .map(([platform, posts]) => ({ platform, reach: sumMetrics(posts).reach }))
+    .sort((a, b) => b.reach - a.reach);
+
+  const topAssister = Object.entries(byEmployee)
+    .map(([employeeId, posts]) => ({
+      employeeId,
+      assists: sumMetrics(posts).assistedConversions,
+    }))
+    .sort((a, b) => b.assists - a.assists)[0];
+  const topAssisterName = topAssister ? (employeeMap[topAssister.employeeId]?.name ?? "the roster") : "the roster";
+
+  const highestRoot = filtered
+    .map((post) => ({
+      post,
+      ripple: ripples
+        .filter((event) => event.rootPostId === post.id)
+        .reduce((sum, event) => sum + (event.value || 0), 0),
+    }))
+    .sort((a, b) => b.ripple - a.ripple)[0];
+
+  const totalSurfaces = Object.keys(byPlatform).length;
+  const conversions = metrics.signups + metrics.paidSubscriptions + metrics.consultingLeads;
+  const ts = metrics.views ? (conversions / metrics.views) * 100 : 0;
+
   return (
-    <div className="space-y-6">
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-6">
-        <MetricCard label="Reach" value={formatNumber(metrics.reach)} icon={Radio} detail="Possessions across public surfaces" />
-        <MetricCard label="Clicks" value={formatNumber(metrics.clicks)} icon={MousePointerClick} detail="Shot attempts and profile clicks" />
-        <MetricCard label="Signups" value={formatNumber(metrics.signups)} icon={Target} detail="Made baskets into owned audience" accent="text-orange-300" />
-        <MetricCard label="Paid Subs" value={formatNumber(metrics.paidSubscriptions)} icon={WalletCards} detail="Three-pointers from social demand" accent="text-orange-300" />
-        <MetricCard label="Consulting" value={formatNumber(metrics.consultingLeads)} icon={Users} detail="And-one high-intent leads" accent="text-red-300" />
-        <MetricCard label="Revenue" value={formatCurrency(metrics.revenue)} icon={Sparkles} detail="Modeled and direct influence" accent="text-red-300" />
-      </section>
+    <Essay
+      cover={
+        <Cover
+          eyebrow="Every Studio · #007 · Briefing"
+          title={
+            <>
+              The Last 90 Days,
+              <br />
+              Read From the Film Room
+            </>
+          }
+          dek={
+            <>
+              A reading of Every&rsquo;s distributed publishing — what landed, what assisted, and the one
+              shot the desk thinks is worth running back.
+            </>
+          }
+          accent={
+            <div className="hidden text-right lg:block">
+              <p className="font-mono text-eyebrow uppercase tracking-ticker text-court-line/70 tabular">
+                Filed
+              </p>
+              <p className="mt-1 font-serif italic text-caption text-court-line/85">{today()}</p>
+              <p className="mt-3 font-mono text-eyebrow uppercase tracking-ticker text-court-line/70 tabular">
+                Issue
+              </p>
+              <p className="font-mono text-stat-lg leading-none text-court-line tabular">#007</p>
+            </div>
+          }
+        />
+      }
+    >
+      <Byline
+        author="The Court Vision desk"
+        agent="Bobbito"
+        date={today()}
+        issue="#007"
+        filedUnder="Every Court Vision · Briefing"
+      />
 
-      <OverviewCharts posts={filtered} employeeMap={employeeMap} />
+      <TLDR
+        bullets={[
+          <>
+            Reach across <span className="font-mono tabular">{totalSurfaces}</span> surfaces totaled{" "}
+            <span className="font-mono tabular">{formatNumber(metrics.reach)}</span> possessions, with the
+            heaviest weight on <strong>{platformByReach[0]?.platform ?? "Newsletter"}</strong> and{" "}
+            <strong>{platformByReach[1]?.platform ?? "LinkedIn"}</strong>.
+          </>,
+          <>
+            Conversion concentrated on <strong>{platformBySignups[0]?.platform ?? "Newsletter"}</strong> —{" "}
+            <span className="font-mono tabular">{formatNumber(platformBySignups[0]?.signups ?? 0)}</span>{" "}
+            signups against <span className="font-mono tabular">{formatNumber(metrics.signups)}</span>{" "}
+            company-wide. Social TS% sits at{" "}
+            <span className="font-mono tabular">{formatPercent(ts, 2)}</span>.
+          </>,
+          <>
+            <strong>{topAssisterName}</strong> led the roster in assists with{" "}
+            <span className="font-mono tabular">{formatNumber(topAssister?.assists ?? 0)}</span> downstream
+            conversions credited — see Fig. 03 for the chalk reading on their best chain.
+          </>,
+          <>
+            Worth running back: the {highestRoot?.post.platform ?? "Newsletter"} post from{" "}
+            <strong>
+              {highestRoot ? (employeeMap[highestRoot.post.employeeId]?.name ?? "the roster") : "the roster"}
+            </strong>{" "}
+            generated the most measurable downstream value of the period.
+          </>,
+        ]}
+      />
 
-      <section className="grid gap-4 xl:grid-cols-[1fr_360px]">
+      <Lede dropCap>
+        Court Vision is not a leaderboard. It&rsquo;s a film room. The job here is to look at what already
+        happened — the reach, the clicks, the assists, the half-finished plays — and read it back the way a
+        coach reads tape on Monday morning. The numbers are real. The story is the part the numbers
+        can&rsquo;t tell.
+      </Lede>
+
+      <Body>
+        Across the period, the desk recorded {formatNumber(filtered.length)} shots from{" "}
+        {totalSurfaces} surfaces, leading to{" "}
+        <span className="font-mono tabular">{formatNumber(conversions)}</span> measurable conversions and{" "}
+        <span className="font-mono tabular">{formatCurrency(metrics.revenue)}</span> in modeled revenue.
+        Volume is necessary, not sufficient: the next three figures separate volume from efficiency, and
+        efficiency from downstream value.
+      </Body>
+
+      {/* Fig. 01 — the six numbers, as count-up tiles. */}
+      <Figure
+        number="01"
+        eyebrow="What happened"
+        title="Six numbers, ninety days."
+        caption="Possessions, attempts, makes — the shape of the company-level box score before any single shot is read on tape."
+        ledeRight={`${formatNumber(filtered.length)} posts`}
+        source="Court Vision corpus"
+        agent="Bobbito"
+        agentPrompt="Walk me through the six metrics for the last 90 days."
+      >
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+          <StatTile
+            label="Reach"
+            value={formatNumber(metrics.reach)}
+            detail="Possessions across public surfaces"
+            trend="up"
+          />
+          <StatTile
+            label="Clicks"
+            value={formatNumber(metrics.clicks)}
+            detail="Shot attempts and profile visits"
+          />
+          <StatTile
+            label="Signups"
+            value={formatNumber(metrics.signups)}
+            detail="Made baskets into owned audience"
+            trend="up"
+          />
+          <StatTile
+            label="Paid Subs"
+            value={formatNumber(metrics.paidSubscriptions)}
+            detail="Three-pointers from social demand"
+          />
+          <StatTile
+            label="Consulting"
+            value={formatNumber(metrics.consultingLeads)}
+            detail="And-one high-intent leads"
+          />
+          <StatTile
+            label="Revenue"
+            value={formatCurrency(metrics.revenue)}
+            detail="Modeled and direct influence"
+            trend="up"
+          />
+        </div>
+      </Figure>
+
+      <Body asides={<>Reach is the easiest number to chase and the easiest to misread. Watch what it sets up, not what it clears.</>}>
+        Reach is what people see; conversion is what they do; assists are what they make easier for someone
+        else. The story of the last ninety days is in the gap between the three. The next figure says it more
+        carefully — surface mix on the left, and the same surfaces re-shaded by what they actually converted on
+        the right.
+      </Body>
+
+      {/* Fig. 02 — surface flow + roster intelligence */}
+      <OverviewFigures posts={filtered} employeeMap={employeeMap} />
+
+      <Body>
+        That&rsquo;s the volume read. The interesting question — the one a film room is built to answer — is
+        what one shot, traced end-to-end, actually <em>created</em>. The next figure is the chalkboard. Each
+        chalk arc is a downstream event the system can attribute to a single root post. Pick a different root
+        and the chalk redraws.
+      </Body>
+
+      {/* Fig. 03 — the centerpiece. Chalk telestrator on court. */}
+      <Figure
+        number="03"
+        eyebrow="The film"
+        title="One root, every echo."
+        caption="Tap any shot to make it the root. The chalk traces every downstream event the system can attribute to it within the period — color-coded by confidence."
+        ledeRight={`${ripples.length} ripple events`}
+        source="Mocked corpus · live in production"
+        agent="Bobbito"
+        agentPrompt="Read the chalk from this root. What does the chain imply about plays we should run again?"
+        surface="court"
+        bleed
+      >
+        <div className="p-3 sm:p-4">
+          <CourtTelestrator
+            posts={filtered}
+            rippleEvents={ripples}
+            employeeMap={employeeMap}
+            height={520}
+          />
+        </div>
+      </Figure>
+
+      <Pull>
+        This is not a leaderboard. The goal is not to make everyone shoot more; it is to understand where each
+        person&rsquo;s best shot creates awareness, trust, conversion, and assists.
+      </Pull>
+
+      <Body>
+        Mode-sensitivity is the second cultural rule of the room: a hard CTA can miss on engagement and still
+        score on signups; a personal product post can miss on direct conversion and still create the assist
+        that makes the next conversion easier. Read the figures with that lens — the same shot can be a miss
+        on Awareness and a make on Trust on the same possession.
+      </Body>
+
+      <Section eyebrow="Platform mix" title="The surfaces, ranked by what they actually did.">
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {cards.map((card) => (
             <PlatformCard key={card.platform} {...card} />
           ))}
         </div>
-        <div className="space-y-4">
-          <InsightCard title="Film Room Thesis" kicker="Cultural Rule">
-            This is not a leaderboard. The goal is not to make everyone shoot more; it is to understand where each
-            person&apos;s best shot creates awareness, trust, conversion, and assists.
-          </InsightCard>
-          <InsightCard title="Mode-Sensitive Outcomes" kicker="Important UX">
-            A hard CTA can miss on engagement and still score on signups. A personal product post can miss on direct
-            conversion and still create hockey assists that make the next conversion easier.
-          </InsightCard>
+      </Section>
+
+      <Section eyebrow="What we&rsquo;re watching" title="Two things the desk wants tape on next.">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <DeskNote
+            kicker="Mode-sensitive outcomes"
+            body="A hard CTA can miss on engagement and still score on signups. A personal product post can miss on direct conversion and still create assists that make the next conversion easier. Worth one more period of tape."
+          />
+          <DeskNote
+            kicker="Trust gravity, by surface"
+            body="Trust accrues on the surface, not the post. Two periods of consistent posting on Newsletter and LinkedIn outperformed three high-virality X spikes for downstream paid conversion."
+          />
         </div>
-      </section>
+      </Section>
+
+      <FourTierFeedback prompt="What did you think of this briefing?" />
+    </Essay>
+  );
+}
+
+function DeskNote({ kicker, body }: { kicker: string; body: string }) {
+  return (
+    <div className="border-l-2 border-confidence-inferred/60 pl-4">
+      <Eyebrow tone="primary">{kicker}</Eyebrow>
+      <p className="mt-2 font-serif text-body italic text-foreground/85">{body}</p>
     </div>
   );
 }

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -37,11 +37,9 @@ export default async function OverviewPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const filters = filtersFromSearchParams(await searchParams);
-  const [roster, filtered, ripples] = await Promise.all([
-    getRoster(),
-    getPosts(filters),
-    getRippleEvents(filters),
-  ]);
+  // Posts feed both the chart figures and the ripple-event scoping; load once, share.
+  const [roster, filtered] = await Promise.all([getRoster(), getPosts(filters)]);
+  const ripples = await getRippleEvents(filters, filtered);
   const metrics = sumMetrics(filtered);
   const cards = platformCards(filtered);
   const employeeMap = employeeMapFromRoster(roster);

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -20,16 +20,18 @@ import { formatCurrency, formatNumber, formatPercent } from "@/lib/formatters";
 import {
   employeeMapFromRoster,
   filtersFromSearchParams,
+  getAllRippleEvents,
   getPosts,
-  getRippleEvents,
   getRoster,
+  scopeRippleEventsToPosts,
 } from "@/lib/queries";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const today = () =>
-  new Intl.DateTimeFormat("en", { month: "long", day: "numeric", year: "numeric" }).format(new Date());
+function formatBriefingDate(d: Date) {
+  return new Intl.DateTimeFormat("en", { month: "long", day: "numeric", year: "numeric" }).format(d);
+}
 
 export default async function OverviewPage({
   searchParams,
@@ -37,9 +39,17 @@ export default async function OverviewPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const filters = filtersFromSearchParams(await searchParams);
-  // Posts feed both the chart figures and the ripple-event scoping; load once, share.
-  const [roster, filtered] = await Promise.all([getRoster(), getPosts(filters)]);
-  const ripples = await getRippleEvents(filters, filtered);
+  // Pin "now" once so Cover and Byline can never disagree across a midnight render.
+  const briefingDate = formatBriefingDate(new Date());
+  // Run all DB round-trips in parallel; scope ripple events to the filtered post
+  // set in memory once everything resolves. Keeps the ripple query concurrent
+  // with the post query instead of serializing behind it.
+  const [roster, filtered, allRippleEvents] = await Promise.all([
+    getRoster(),
+    getPosts(filters),
+    getAllRippleEvents(),
+  ]);
+  const ripples = scopeRippleEventsToPosts(allRippleEvents, filtered);
   const metrics = sumMetrics(filtered);
   const cards = platformCards(filtered);
   const employeeMap = employeeMapFromRoster(roster);
@@ -102,7 +112,7 @@ export default async function OverviewPage({
               <p className="font-mono text-eyebrow uppercase tracking-ticker text-court-line/70 tabular">
                 Filed
               </p>
-              <p className="mt-1 font-serif italic text-caption text-court-line/85">{today()}</p>
+              <p className="mt-1 font-serif italic text-caption text-court-line/85">{briefingDate}</p>
               <p className="mt-3 font-mono text-eyebrow uppercase tracking-ticker text-court-line/70 tabular">
                 Issue
               </p>
@@ -115,7 +125,7 @@ export default async function OverviewPage({
       <Byline
         author="The Court Vision desk"
         agent="Bobbito"
-        date={today()}
+        date={briefingDate}
         issue="#007"
         filedUnder="Every Court Vision · Briefing"
       />

--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -66,13 +66,15 @@ export default async function OverviewPage({
     .sort((a, b) => b.assists - a.assists)[0];
   const topAssisterName = topAssister ? (employeeMap[topAssister.employeeId]?.name ?? "the roster") : "the roster";
 
+  // Pre-aggregate ripple value by root in a single pass, then index posts in O(N).
+  const rippleSumByRoot = ripples.reduce<Map<string, number>>((acc, event) => {
+    if (!event.rootPostId) return acc;
+    acc.set(event.rootPostId, (acc.get(event.rootPostId) ?? 0) + (event.value || 0));
+    return acc;
+  }, new Map());
+
   const highestRoot = filtered
-    .map((post) => ({
-      post,
-      ripple: ripples
-        .filter((event) => event.rootPostId === post.id)
-        .reduce((sum, event) => sum + (event.value || 0), 0),
-    }))
+    .map((post) => ({ post, ripple: rippleSumByRoot.get(post.id) ?? 0 }))
     .sort((a, b) => b.ripple - a.ripple)[0];
 
   const totalSurfaces = Object.keys(byPlatform).length;

--- a/app/shot-plot/page.tsx
+++ b/app/shot-plot/page.tsx
@@ -1,6 +1,15 @@
 import { Badge } from "@/components/ui/badge";
 import { ShotPlot } from "@/components/ShotPlot";
-import { employeeMapFromRoster, filtersFromSearchParams, getPlays, getPosts, getRippleEvents, getRoster, playMapFromPlays } from "@/lib/queries";
+import {
+  employeeMapFromRoster,
+  filtersFromSearchParams,
+  getAllRippleEvents,
+  getPlays,
+  getPosts,
+  getRoster,
+  playMapFromPlays,
+  scopeRippleEventsToPosts,
+} from "@/lib/queries";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,9 +20,15 @@ export default async function ShotPlotPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const filters = filtersFromSearchParams(await searchParams);
-  // Posts feed both the chart and the ripple-event scoping; load once, share.
-  const [filtered, roster, plays] = await Promise.all([getPosts(filters), getRoster(), getPlays()]);
-  const rippleEvents = await getRippleEvents(filters, filtered);
+  // Run all four DB round-trips in parallel; scope ripple events to the
+  // filtered post set in memory once everything resolves.
+  const [filtered, roster, plays, allRippleEvents] = await Promise.all([
+    getPosts(filters),
+    getRoster(),
+    getPlays(),
+    getAllRippleEvents(),
+  ]);
+  const rippleEvents = scopeRippleEventsToPosts(allRippleEvents, filtered);
   const employeeMap = employeeMapFromRoster(roster);
   const playMap = playMapFromPlays(plays);
 

--- a/app/shot-plot/page.tsx
+++ b/app/shot-plot/page.tsx
@@ -11,12 +11,9 @@ export default async function ShotPlotPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const filters = filtersFromSearchParams(await searchParams);
-  const [filtered, roster, plays, rippleEvents] = await Promise.all([
-    getPosts(filters),
-    getRoster(),
-    getPlays(),
-    getRippleEvents(filters),
-  ]);
+  // Posts feed both the chart and the ripple-event scoping; load once, share.
+  const [filtered, roster, plays] = await Promise.all([getPosts(filters), getRoster(), getPlays()]);
+  const rippleEvents = await getRippleEvents(filters, filtered);
   const employeeMap = employeeMapFromRoster(roster);
   const playMap = playMapFromPlays(plays);
 

--- a/components/CourtTelestrator.tsx
+++ b/components/CourtTelestrator.tsx
@@ -174,8 +174,15 @@ export function CourtTelestrator({
         </div>
       </div>
 
-      {/* The court canvas — aspect-ratio locked to the viewBox so the HTML
-         click-overlay coordinates (CSS %) stay aligned with SVG content. */}
+      {/* The court canvas. The HTML click-overlay below positions buttons in CSS
+         percentages relative to this container; for that to line up with the SVG
+         content at every viewport size we tell the SVG to stretch to fill the
+         container exactly (`preserveAspectRatio="none"`). The container still
+         carries an `aspectRatio` hint so the default rendering matches the
+         viewBox, but `minHeight` can override it on narrow widths — and with
+         `none` the SVG follows whatever shape the container takes, so the
+         overlay never desyncs. The court diagram is symmetric enough that minor
+         non-uniform scaling reads fine. */}
       <div
         className="relative overflow-hidden rounded-sm border border-court-line/15 bg-[radial-gradient(circle_at_30%_-10%,rgba(255,157,66,0.06),transparent_55%),radial-gradient(circle_at_75%_120%,rgba(85,167,255,0.05),transparent_60%),hsl(var(--court-paint))]"
         style={{ aspectRatio: `${VW}/${VH}`, minHeight: compact ? 320 : height }}
@@ -183,7 +190,7 @@ export function CourtTelestrator({
         <svg
           viewBox={`0 0 ${VW} ${VH}`}
           className="h-full min-h-[inherit] w-full"
-          preserveAspectRatio="xMidYMid meet"
+          preserveAspectRatio="none"
         >
           <defs>
             <filter id={ids.softGlow}>

--- a/components/CourtTelestrator.tsx
+++ b/components/CourtTelestrator.tsx
@@ -74,6 +74,22 @@ export function CourtTelestrator({
   }, [defaultPostId, posts, ripplesByRoot]);
 
   const [internalSelected, setInternalSelected] = useState<string | undefined>(autoFocusId);
+
+  // Resync uncontrolled focus when filters change. If the upstream auto-focus has
+  // moved (because posts/ripples shifted) AND the current selection isn't in the
+  // new visible post set, fall back to the new auto-focus. If the user's pick is
+  // still valid in the new set, keep it — filter shouldn't blow away a click.
+  // Inline state-update-from-prop pattern (no useEffect) per React docs.
+  const [prevAutoFocusId, setPrevAutoFocusId] = useState<string | undefined>(autoFocusId);
+  if (autoFocusId !== prevAutoFocusId) {
+    setPrevAutoFocusId(autoFocusId);
+    if (selectedPostId === undefined) {
+      const stillValid =
+        internalSelected !== undefined && posts.some((p) => p.id === internalSelected);
+      if (!stillValid) setInternalSelected(autoFocusId);
+    }
+  }
+
   const focusId = selectedPostId ?? internalSelected;
   const focusPost = useMemo(() => posts.find((p) => p.id === focusId), [posts, focusId]);
   const focusRipples = useMemo(

--- a/components/CourtTelestrator.tsx
+++ b/components/CourtTelestrator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -100,6 +100,19 @@ export function CourtTelestrator({
   // Time scrubber — controls how many ripples have "happened" yet.
   // Reset progress to total whenever the focus changes (canonical "reset on prop change"
   // pattern: track previous prop in render, reset state inline — no useEffect needed).
+  // Scope SVG defs to this instance so multiple telestrators on the same page
+  // (e.g. on a player profile) don't fight over global filter/gradient ids.
+  const idBase = useId();
+  const ids = useMemo(
+    () => ({
+      softGlow: `${idBase}-soft-glow`,
+      chalk: `${idBase}-chalk`,
+      paint: `${idBase}-paint`,
+      grid: `${idBase}-grid`,
+    }),
+    [idBase],
+  );
+
   const total = focusRipples.length;
   const [progress, setProgress] = useState(total);
   const [prevTotal, setPrevTotal] = useState(total);
@@ -172,29 +185,29 @@ export function CourtTelestrator({
           preserveAspectRatio="xMidYMid meet"
         >
           <defs>
-            <filter id="cv-soft-glow">
+            <filter id={ids.softGlow}>
               <feGaussianBlur stdDeviation="0.7" />
               <feMerge>
                 <feMergeNode />
                 <feMergeNode in="SourceGraphic" />
               </feMerge>
             </filter>
-            <filter id="cv-chalk" x="-10%" y="-10%" width="120%" height="120%">
+            <filter id={ids.chalk} x="-10%" y="-10%" width="120%" height="120%">
               <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" />
               <feDisplacementMap in="SourceGraphic" scale="0.35" />
             </filter>
-            <linearGradient id="cv-paint" x1="0" x2="0" y1="0" y2="1">
+            <linearGradient id={ids.paint} x1="0" x2="0" y1="0" y2="1">
               <stop offset="0%" stopColor="hsl(var(--court-paint))" stopOpacity="0.85" />
               <stop offset="100%" stopColor="hsl(var(--court-wood))" stopOpacity="0.95" />
             </linearGradient>
-            <pattern id="cv-grid" width="6" height="6" patternUnits="userSpaceOnUse">
+            <pattern id={ids.grid} width="6" height="6" patternUnits="userSpaceOnUse">
               <path d="M6 0H0V6" fill="none" stroke="hsl(var(--court-line) / 0.06)" strokeWidth="0.15" />
             </pattern>
           </defs>
 
           {/* Court substrate */}
-          <rect x="0" y="0" width={VW} height={VH} fill="url(#cv-paint)" />
-          <rect x="0" y="0" width={VW} height={VH} fill="url(#cv-grid)" />
+          <rect x="0" y="0" width={VW} height={VH} fill={`url(#${ids.paint})`} />
+          <rect x="0" y="0" width={VW} height={VH} fill={`url(#${ids.grid})`} />
           <rect
             x="1.5"
             y="1.5"
@@ -293,7 +306,7 @@ export function CourtTelestrator({
                 fill="hsl(var(--court-orange))"
                 stroke="white"
                 strokeWidth="0.45"
-                filter="url(#cv-soft-glow)"
+                filter={`url(#${ids.softGlow})`}
               />
               <circle cx={focusPost.x} cy={focusPost.y} r="6.5" fill="none" stroke="hsl(var(--court-orange) / 0.45)" strokeWidth="0.35" />
               <text

--- a/components/CourtTelestrator.tsx
+++ b/components/CourtTelestrator.tsx
@@ -174,10 +174,11 @@ export function CourtTelestrator({
         </div>
       </div>
 
-      {/* The court canvas */}
+      {/* The court canvas — aspect-ratio locked to the viewBox so the HTML
+         click-overlay coordinates (CSS %) stay aligned with SVG content. */}
       <div
         className="relative overflow-hidden rounded-sm border border-court-line/15 bg-[radial-gradient(circle_at_30%_-10%,rgba(255,157,66,0.06),transparent_55%),radial-gradient(circle_at_75%_120%,rgba(85,167,255,0.05),transparent_60%),hsl(var(--court-paint))]"
-        style={{ minHeight: compact ? 320 : height }}
+        style={{ aspectRatio: `${VW}/${VH}`, minHeight: compact ? 320 : height }}
       >
         <svg
           viewBox={`0 0 ${VW} ${VH}`}

--- a/components/CourtTelestrator.tsx
+++ b/components/CourtTelestrator.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Employee, Post, RippleEvent } from "@/lib/types";
+
+/**
+ * CourtTelestrator — the centerpiece. Chalk-on-court view that collapses
+ * Court Heat + Shot Plot + Ripple Graph + Stream into a single performing surface.
+ *
+ * Visual grammar (per brief):
+ *  - every.to spine: lives inside an essay <Figure> wrapper, prose is the frame.
+ *  - ESPN broadcast: chalk telestrator drawn over a real court diagram.
+ *  - hex.tech: big breathing canvas, minimal chrome, eyebrow-title-caption rhythm
+ *    (those three live on the wrapping <Figure>; here we own the canvas).
+ *  - NBA Street Vol. 2: rare GameBreaker overlay when `gamebreakerLevel > 0`.
+ */
+export function CourtTelestrator({
+  posts,
+  rippleEvents,
+  employeeMap = {},
+  selectedPostId,
+  defaultPostId,
+  onSelect,
+  height = 560,
+  compact = false,
+  gamebreakerLevel = 0,
+  className,
+}: {
+  posts: Post[];
+  rippleEvents: RippleEvent[];
+  employeeMap?: Record<string, Employee>;
+  selectedPostId?: string;
+  /** Initial focus when uncontrolled. Defaults to the post with the most ripple value. */
+  defaultPostId?: string;
+  onSelect?: (postId: string | undefined) => void;
+  height?: number;
+  compact?: boolean;
+  /** 0 = none, 1 = first viral threshold, 2 = teammate assist confirmed, 3 = full chain. */
+  gamebreakerLevel?: 0 | 1 | 2 | 3;
+  className?: string;
+}) {
+  // Auto-pick the most "telestrator-worthy" shot if no selection — the post whose
+  // ripple chain has the most total downstream value.
+  const ripplesByRoot = useMemo(() => {
+    const map = new Map<string, RippleEvent[]>();
+    for (const ev of rippleEvents) {
+      if (!ev.rootPostId) continue;
+      const arr = map.get(ev.rootPostId) ?? [];
+      arr.push(ev);
+      map.set(ev.rootPostId, arr);
+    }
+    for (const [, arr] of map) {
+      arr.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+    }
+    return map;
+  }, [rippleEvents]);
+
+  const autoFocusId = useMemo(() => {
+    if (defaultPostId) return defaultPostId;
+    let bestId: string | undefined;
+    let best = -1;
+    for (const [postId, evs] of ripplesByRoot) {
+      const score = evs.reduce((s, e) => s + (e.value || 0), 0);
+      if (score > best) {
+        best = score;
+        bestId = postId;
+      }
+    }
+    return bestId ?? posts[0]?.id;
+  }, [defaultPostId, posts, ripplesByRoot]);
+
+  const [internalSelected, setInternalSelected] = useState<string | undefined>(autoFocusId);
+  const focusId = selectedPostId ?? internalSelected;
+  const focusPost = useMemo(() => posts.find((p) => p.id === focusId), [posts, focusId]);
+  const focusRipples = useMemo(
+    () => (focusId ? (ripplesByRoot.get(focusId) ?? []) : []),
+    [focusId, ripplesByRoot],
+  );
+
+  // Time scrubber — controls how many ripples have "happened" yet.
+  // Reset progress to total whenever the focus changes (canonical "reset on prop change"
+  // pattern: track previous prop in render, reset state inline — no useEffect needed).
+  const total = focusRipples.length;
+  const [progress, setProgress] = useState(total);
+  const [prevTotal, setPrevTotal] = useState(total);
+  if (prevTotal !== total) {
+    setPrevTotal(total);
+    setProgress(total);
+  }
+
+  const visibleRipples = focusRipples.slice(0, progress);
+
+  const handleSelect = (id: string | undefined) => {
+    if (selectedPostId === undefined) setInternalSelected(id);
+    onSelect?.(id);
+  };
+
+  // SVG canvas geometry. Court is 100x94; pad so chalk strokes can extend off-court.
+  const VW = 100;
+  const VH = 94;
+
+  // Position ripple endpoints on a fan around the root post.
+  const ripplePositions = useMemo(() => {
+    if (!focusPost) return [] as { ev: RippleEvent; x: number; y: number; arcId: string }[];
+    return focusRipples.map((ev, i) => {
+      // Spread around root. Vary radius by index so chains feel organic.
+      const angleStart = -Math.PI * 0.65;
+      const angleEnd = Math.PI * 0.35;
+      const t = focusRipples.length === 1 ? 0.5 : i / (focusRipples.length - 1);
+      const angle = angleStart + (angleEnd - angleStart) * t;
+      const radius = 18 + (i % 3) * 7 + Math.sin(i * 1.7) * 3;
+      let x = focusPost.x + Math.cos(angle) * radius;
+      let y = focusPost.y + Math.sin(angle) * radius;
+      // Clamp to canvas with margin so labels stay in frame.
+      x = Math.max(8, Math.min(VW - 8, x));
+      y = Math.max(8, Math.min(VH - 8, y));
+      return { ev, x, y, arcId: `arc-${focusPost.id}-${ev.id}` };
+    });
+  }, [focusPost, focusRipples]);
+
+  return (
+    <div className={cn("relative isolate", className)}>
+      {/* GameBreaker overlay — rare, only fires when caller passes a level. */}
+      {gamebreakerLevel === 1 || gamebreakerLevel === 2 || gamebreakerLevel === 3 ? (
+        <GameBreakerOverlay level={gamebreakerLevel} />
+      ) : null}
+
+      {/* Top chrome — ticker scoreboard + selection chip */}
+      <div className="flex flex-wrap items-baseline justify-between gap-3 px-1 pb-3 sm:px-2">
+        <div className="flex items-baseline gap-3">
+          <span className="font-mono text-eyebrow uppercase tracking-ticker text-court-orange tabular">
+            Telestrator · {employeeMap[focusPost?.employeeId ?? ""]?.name ?? "Roster"}
+          </span>
+          <span className="font-serif italic text-caption text-muted-foreground">
+            {focusPost ? focusPost.platform : "—"} · {focusRipples.length} downstream events
+          </span>
+        </div>
+        <div className="flex items-center gap-1 font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+          <span aria-hidden className="size-1.5 rounded-full bg-confidence-direct animate-pulse" />
+          LIVE READING
+        </div>
+      </div>
+
+      {/* The court canvas */}
+      <div
+        className="relative overflow-hidden rounded-sm border border-court-line/15 bg-[radial-gradient(circle_at_30%_-10%,rgba(255,157,66,0.06),transparent_55%),radial-gradient(circle_at_75%_120%,rgba(85,167,255,0.05),transparent_60%),hsl(var(--court-paint))]"
+        style={{ minHeight: compact ? 320 : height }}
+      >
+        <svg
+          viewBox={`0 0 ${VW} ${VH}`}
+          className="h-full min-h-[inherit] w-full"
+          preserveAspectRatio="xMidYMid meet"
+        >
+          <defs>
+            <filter id="cv-soft-glow">
+              <feGaussianBlur stdDeviation="0.7" />
+              <feMerge>
+                <feMergeNode />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+            <filter id="cv-chalk" x="-10%" y="-10%" width="120%" height="120%">
+              <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" />
+              <feDisplacementMap in="SourceGraphic" scale="0.35" />
+            </filter>
+            <linearGradient id="cv-paint" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stopColor="hsl(var(--court-paint))" stopOpacity="0.85" />
+              <stop offset="100%" stopColor="hsl(var(--court-wood))" stopOpacity="0.95" />
+            </linearGradient>
+            <pattern id="cv-grid" width="6" height="6" patternUnits="userSpaceOnUse">
+              <path d="M6 0H0V6" fill="none" stroke="hsl(var(--court-line) / 0.06)" strokeWidth="0.15" />
+            </pattern>
+          </defs>
+
+          {/* Court substrate */}
+          <rect x="0" y="0" width={VW} height={VH} fill="url(#cv-paint)" />
+          <rect x="0" y="0" width={VW} height={VH} fill="url(#cv-grid)" />
+          <rect
+            x="1.5"
+            y="1.5"
+            width={VW - 3}
+            height={VH - 3}
+            fill="none"
+            stroke="hsl(var(--court-line) / 0.55)"
+            strokeWidth="0.35"
+          />
+          {/* Half-court line */}
+          <line
+            x1={VW / 2}
+            x2={VW / 2}
+            y1="1.5"
+            y2={VH - 1.5}
+            stroke="hsl(var(--court-line) / 0.32)"
+            strokeWidth="0.25"
+          />
+          {/* Center jump circle */}
+          <circle cx={VW / 2} cy={VH / 2} r="11" fill="none" stroke="hsl(var(--court-line) / 0.32)" strokeWidth="0.3" />
+          <circle cx={VW / 2} cy={VH / 2} r="2.4" fill="none" stroke="hsl(var(--court-line) / 0.4)" strokeWidth="0.3" />
+          {/* Three-point arcs */}
+          <path
+            d={`M 25 ${VH - 2} A 25 25 0 0 1 75 ${VH - 2}`}
+            fill="none"
+            stroke="hsl(var(--court-line) / 0.4)"
+            strokeWidth="0.4"
+          />
+          <path d="M 25 2 A 25 25 0 0 0 75 2" fill="none" stroke="hsl(var(--court-line) / 0.4)" strokeWidth="0.4" />
+          {/* Paint */}
+          <rect x="38" y={VH - 24} width="24" height="22" fill="hsl(var(--court-line) / 0.05)" stroke="hsl(var(--court-line) / 0.3)" strokeWidth="0.32" />
+          <rect x="38" y="2" width="24" height="22" fill="hsl(var(--court-line) / 0.04)" stroke="hsl(var(--court-line) / 0.22)" strokeWidth="0.32" />
+          {/* Free-throw circles */}
+          <circle cx="50" cy={VH - 24} r="8" fill="none" stroke="hsl(var(--court-line) / 0.3)" strokeWidth="0.3" />
+          <circle cx="50" cy="24" r="8" fill="none" stroke="hsl(var(--court-line) / 0.2)" strokeWidth="0.3" />
+
+          {/* Ambient — every shot in the corpus, faint, so the canvas reads as full of action. */}
+          {posts.map((p) => {
+            const focused = p.id === focusId;
+            return (
+              <motion.circle
+                key={`bg-${p.id}`}
+                cx={p.x}
+                cy={p.y}
+                r={focused ? 1.8 : 0.85}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: focused ? 1 : 0.32 }}
+                transition={{ duration: 0.5 }}
+                fill={focused ? "hsl(var(--court-orange))" : "hsl(var(--court-line))"}
+                stroke={focused ? "white" : "none"}
+                strokeWidth={focused ? 0.4 : 0}
+              />
+            );
+          })}
+
+          {/* Chalk arcs from root → each ripple */}
+          {focusPost
+            ? ripplePositions.slice(0, progress).map(({ ev, x, y, arcId }, i) => {
+                // Cubic bezier with chalk styling
+                const ctrlX = (focusPost.x + x) / 2 + (i % 2 === 0 ? 8 : -8);
+                const ctrlY = (focusPost.y + y) / 2 - 12;
+                const d = `M ${focusPost.x} ${focusPost.y} Q ${ctrlX} ${ctrlY} ${x} ${y}`;
+                return (
+                  <g key={arcId}>
+                    <path
+                      d={d}
+                      fill="none"
+                      className="chalk-stroke animate-draw-in"
+                      strokeWidth={0.5 + Math.min(0.6, (ev.value || 0) / 4000)}
+                      style={{ ['--length' as never]: 80, animationDelay: `${i * 0.18}s` }}
+                    />
+                    {/* Subtle echo line beneath — sketchy double-stroke chalk feel */}
+                    <path
+                      d={d}
+                      fill="none"
+                      stroke="hsl(var(--court-line) / 0.22)"
+                      strokeWidth="0.85"
+                      strokeLinecap="round"
+                    />
+                  </g>
+                );
+              })
+            : null}
+
+          {/* Focus shot — the root post, drawn loud */}
+          {focusPost ? (
+            <motion.g
+              initial={{ scale: 0.85, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.1, type: "spring", stiffness: 220, damping: 18 }}
+            >
+              <circle
+                cx={focusPost.x}
+                cy={focusPost.y}
+                r="3.2"
+                fill="hsl(var(--court-orange))"
+                stroke="white"
+                strokeWidth="0.45"
+                filter="url(#cv-soft-glow)"
+              />
+              <circle cx={focusPost.x} cy={focusPost.y} r="6.5" fill="none" stroke="hsl(var(--court-orange) / 0.45)" strokeWidth="0.35" />
+              <text
+                x={focusPost.x}
+                y={focusPost.y - 5}
+                textAnchor="middle"
+                className="fill-court-line"
+                style={{ fontFamily: "var(--font-chalk), cursive", fontSize: "2.2px" }}
+              >
+                ROOT · {employeeMap[focusPost.employeeId]?.name?.split(" ")[0] ?? focusPost.platform}
+              </text>
+            </motion.g>
+          ) : null}
+
+          {/* Ripple endpoints — chalk dots with labels */}
+          {visibleRipples.map((ev, i) => {
+            const pos = ripplePositions[i];
+            if (!pos) return null;
+            const tone =
+              ev.confidence === "Direct"
+                ? "hsl(var(--confidence-direct))"
+                : ev.confidence === "Estimated" || ev.confidence === "Modeled"
+                  ? "hsl(var(--confidence-strong))"
+                  : "hsl(var(--confidence-inferred))";
+            return (
+              <motion.g
+                key={`ripple-${ev.id}`}
+                initial={{ opacity: 0, scale: 0.6 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 0.35 + i * 0.16, type: "spring", stiffness: 260, damping: 20 }}
+              >
+                <circle cx={pos.x} cy={pos.y} r="2.2" fill={tone} stroke="white" strokeWidth="0.3" />
+                <circle cx={pos.x} cy={pos.y} r="4" fill="none" stroke={tone} strokeOpacity="0.4" strokeWidth="0.3" />
+                <text
+                  x={pos.x}
+                  y={pos.y - 4.5}
+                  textAnchor="middle"
+                  className="fill-court-line"
+                  style={{ fontFamily: "var(--font-chalk), cursive", fontSize: "1.9px" }}
+                >
+                  {ev.eventType.split(" ").slice(0, 3).join(" ")}
+                </text>
+                <text
+                  x={pos.x}
+                  y={pos.y + 5.5}
+                  textAnchor="middle"
+                  className="fill-court-line/70"
+                  style={{ fontFamily: "var(--font-geist-mono), monospace", fontSize: "1.55px", letterSpacing: "0.06em" }}
+                >
+                  {ev.value ? `+${formatTicker(ev.value)}` : ev.platform.toUpperCase()}
+                </text>
+              </motion.g>
+            );
+          })}
+        </svg>
+
+        {/* Click-overlay: each post as a hit-target so users can re-focus the telestrator */}
+        <div className="absolute inset-0">
+          {posts.map((p) => (
+            <button
+              key={`hit-${p.id}`}
+              type="button"
+              onClick={() => handleSelect(p.id)}
+              aria-label={`Focus on ${employeeMap[p.employeeId]?.name ?? p.platform} post`}
+              className={cn(
+                "absolute size-7 -translate-x-1/2 -translate-y-1/2 rounded-full",
+                "transition-colors hover:bg-white/[0.04] focus-visible:bg-white/[0.06] focus-visible:outline-none",
+                p.id === focusId && "bg-court-orange/10",
+              )}
+              style={{ left: `${p.x}%`, top: `${(p.y / VH) * 100}%` }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Scrubber — halftime show timeline */}
+      {total > 1 ? (
+        <div className="mt-4 flex flex-col gap-2 px-1 sm:px-2">
+          <div className="flex items-center gap-3">
+            <span className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+              Replay
+            </span>
+            <input
+              type="range"
+              min={1}
+              max={total}
+              step={1}
+              value={progress}
+              onChange={(e) => setProgress(Number(e.target.value))}
+              aria-label="Telestrator replay scrubber"
+              className="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-court-line/15 accent-court-orange"
+            />
+            <span className="font-mono text-eyebrow uppercase tracking-ticker text-foreground tabular">
+              {progress}/{total}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setProgress(total)}
+              className="h-7 px-3 font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground hover:text-foreground tabular"
+            >
+              End
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setProgress(1)}
+              className="h-7 px-3 font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground hover:text-foreground tabular"
+            >
+              Start
+            </Button>
+          </div>
+
+          {/* Chapter markers — the events themselves, dotted along the bar */}
+          <div className="relative h-6">
+            {focusRipples.map((ev, i) => {
+              const left = total <= 1 ? 0 : (i / (total - 1)) * 100;
+              const visible = i < progress;
+              return (
+                <div
+                  key={`chapter-${ev.id}`}
+                  className={cn(
+                    "absolute -translate-x-1/2 transition-opacity",
+                    visible ? "opacity-100" : "opacity-30",
+                  )}
+                  style={{ left: `${left}%` }}
+                >
+                  <div className="h-2 w-px bg-court-line/40" />
+                  <div className="mt-1 whitespace-nowrap font-mono text-[9px] uppercase tracking-[0.18em] text-muted-foreground tabular">
+                    {ev.eventType.split(" ")[0]}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatTicker(n: number) {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(Math.round(n));
+}
+
+/**
+ * GameBreakerOverlay — the rare NBA Street Vol. 2 celebration.
+ *
+ * Used sparingly. Three escalating tiers (level 1/2/3). Holographic edge highlights,
+ * brief screen-shake (subtle), spray-paint display type. Default state is calm.
+ */
+function GameBreakerOverlay({ level }: { level: 1 | 2 | 3 }) {
+  const wrap = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = wrap.current;
+    if (!node) return;
+    node.animate(
+      [
+        { transform: "translate3d(0,0,0)" },
+        { transform: "translate3d(-2px, 1px, 0)" },
+        { transform: "translate3d(2px, -1px, 0)" },
+        { transform: "translate3d(-1px, 0, 0)" },
+        { transform: "translate3d(0,0,0)" },
+      ],
+      { duration: 380, iterations: level },
+    );
+  }, [level]);
+
+  const labels: Record<1 | 2 | 3, string> = {
+    1: "Game Breaker 1",
+    2: "Game Breaker 2",
+    3: "Game Breaker 3",
+  };
+
+  return (
+    <div ref={wrap} className="pointer-events-none absolute inset-0 z-10 overflow-hidden">
+      {/* Holographic ring on the canvas border */}
+      <div className="absolute inset-0 rounded-sm ring-1 ring-court-line/40" />
+      <div
+        className="absolute inset-0 rounded-sm"
+        style={{
+          boxShadow: "inset 0 0 60px rgba(255,157,66,0.18), inset 0 0 120px rgba(85,167,255,0.12)",
+        }}
+      />
+      <div className="absolute right-4 top-4 sm:right-6 sm:top-6">
+        <div
+          className={cn(
+            "gamebreaker text-3xl sm:text-5xl holographic font-black",
+            "drop-shadow-[0_2px_0_rgba(0,0,0,0.55)]",
+          )}
+        >
+          {labels[level]}
+        </div>
+        <div className="mt-1 text-right font-mono text-eyebrow uppercase tracking-ticker text-court-line/80 tabular">
+          {level === 1
+            ? "Viral threshold cleared"
+            : level === 2
+              ? "Teammate assist confirmed"
+              : "Full chain conversion"}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/OverviewFigures.tsx
+++ b/components/OverviewFigures.tsx
@@ -1,0 +1,83 @@
+import { Figure } from "@/components/essay";
+import { OverviewSurfaceChart, OverviewRosterChart } from "@/components/OverviewFiguresClient";
+import { groupPosts, sumMetrics } from "@/lib/aggregations";
+import type { Employee, Post } from "@/lib/types";
+
+/**
+ * Two inline figures that anchor the /overview essay's middle act:
+ *
+ *   Fig. 02 — surface flow (reach → signups across the platform set)
+ *   Fig. 02b — roster intelligence (Trust × Social TS% × Assists)
+ *
+ * Splits the existing OverviewCharts into two Figure-wrapped panels so the
+ * editorial rhythm (eyebrow → title → caption → chart → Read with Bobbito) lands
+ * on each chart. Computes data server-side, hands typed shapes to the client charts.
+ */
+export function OverviewFigures({
+  posts,
+  employeeMap,
+}: {
+  posts: Post[];
+  employeeMap: Record<string, Employee>;
+}) {
+  const platformData = Object.entries(groupPosts(posts, (post) => post.platform)).map(
+    ([platform, group]) => {
+      const m = sumMetrics(group);
+      return {
+        platform,
+        reach: m.reach,
+        signups: m.signups,
+        paid: m.paidSubscriptions,
+        consulting: m.consultingLeads,
+        assists: m.assistedConversions,
+      };
+    },
+  );
+
+  const employeeData = Object.entries(groupPosts(posts, (post) => post.employeeId))
+    .map(([employeeId, group]) => {
+      const m = sumMetrics(group);
+      return {
+        name: employeeMap[employeeId]?.name.split(" ")[0] ?? employeeId,
+        Trust: group.reduce((s, p) => s + p.scores.trustGravity, 0) / Math.max(1, group.length),
+        "Social TS": group.reduce((s, p) => s + p.scores.socialTS, 0) / Math.max(1, group.length),
+        Assists: m.assistedConversions / 10,
+      };
+    })
+    .sort((a, b) => b.Trust - a.Trust)
+    .slice(0, 8);
+
+  return (
+    <div className="space-y-2 lg:space-y-4">
+      <Figure
+        number="02"
+        eyebrow="Surface flow"
+        title="Reach didn&rsquo;t go where conversion went."
+        caption="Platform-level: blue line is reach (possessions); orange-filled line is signups (made baskets). Where they diverge, the surface earned attention without earning action — or vice versa."
+        ledeRight={`${platformData.length} surfaces`}
+        source="Aggregated platform metrics"
+        agent="Bobbito"
+        agentPrompt="Where did reach lead conversion this period, and where did it just make noise?"
+      >
+        <div className="h-80 sm:h-96">
+          <OverviewSurfaceChart data={platformData} />
+        </div>
+      </Figure>
+
+      <Figure
+        number="02b"
+        eyebrow="Roster intelligence"
+        title="Trust, TS%, and assist profile by player."
+        caption="Top eight by Trust Gravity. Tall purple bar = the player&rsquo;s audience treats their posts as signal; tall teal = they convert efficiently per attempt; tall orange = they make their teammates&rsquo; next shots easier."
+        ledeRight={`${employeeData.length}/${Object.keys(employeeMap).length} shown`}
+        source="Per-author scoring corpus"
+        agent="Bobbito"
+        agentPrompt="Read the bar mix per player. Who&rsquo;s the assist engine no one&rsquo;s named?"
+      >
+        <div className="h-80 sm:h-96">
+          <OverviewRosterChart data={employeeData} />
+        </div>
+      </Figure>
+    </div>
+  );
+}

--- a/components/OverviewFigures.tsx
+++ b/components/OverviewFigures.tsx
@@ -34,14 +34,24 @@ export function OverviewFigures({
     },
   );
 
+  // Single pass per employee — accumulate trust, TS, and assists in one loop instead
+  // of running sumMetrics + two separate reduces.
   const employeeData = Object.entries(groupPosts(posts, (post) => post.employeeId))
     .map(([employeeId, group]) => {
-      const m = sumMetrics(group);
+      let totalTrust = 0;
+      let totalSocialTS = 0;
+      let assistedConversions = 0;
+      for (const post of group) {
+        totalTrust += post.scores.trustGravity;
+        totalSocialTS += post.scores.socialTS;
+        assistedConversions += post.metrics.assistedConversions;
+      }
+      const count = Math.max(1, group.length);
       return {
         name: employeeMap[employeeId]?.name.split(" ")[0] ?? employeeId,
-        Trust: group.reduce((s, p) => s + p.scores.trustGravity, 0) / Math.max(1, group.length),
-        "Social TS": group.reduce((s, p) => s + p.scores.socialTS, 0) / Math.max(1, group.length),
-        Assists: m.assistedConversions / 10,
+        Trust: totalTrust / count,
+        "Social TS": totalSocialTS / count,
+        Assists: assistedConversions / 10,
       };
     })
     .sort((a, b) => b.Trust - a.Trust)

--- a/components/OverviewFigures.tsx
+++ b/components/OverviewFigures.tsx
@@ -35,7 +35,10 @@ export function OverviewFigures({
   );
 
   // Single pass per employee — accumulate trust, TS, and assists in one loop instead
-  // of running sumMetrics + two separate reduces.
+  // of running sumMetrics + two separate reduces. Trust and Social TS are 0–100
+  // scores; Assists are raw conversion counts on a different magnitude. Recharts
+  // auto-scales the y-axis to fit; the legend tells the truth without an ad-hoc
+  // ÷ 10 normalization that would confuse tooltip values.
   const employeeData = Object.entries(groupPosts(posts, (post) => post.employeeId))
     .map(([employeeId, group]) => {
       let totalTrust = 0;
@@ -51,7 +54,7 @@ export function OverviewFigures({
         name: employeeMap[employeeId]?.name.split(" ")[0] ?? employeeId,
         Trust: totalTrust / count,
         "Social TS": totalSocialTS / count,
-        Assists: assistedConversions / 10,
+        Assists: assistedConversions,
       };
     })
     .sort((a, b) => b.Trust - a.Trust)
@@ -78,7 +81,7 @@ export function OverviewFigures({
         number="02b"
         eyebrow="Roster intelligence"
         title="Trust, TS%, and assist profile by player."
-        caption="Top eight by Trust Gravity. Tall purple bar = the player&rsquo;s audience treats their posts as signal; tall teal = they convert efficiently per attempt; tall orange = they make their teammates&rsquo; next shots easier."
+        caption="Top eight by Trust Gravity. Trust and Social TS are 0–100 scores; Assists are raw downstream conversions credited — different magnitudes share one axis on purpose, so the assist engines stand out where they should."
         ledeRight={`${employeeData.length}/${Object.keys(employeeMap).length} shown`}
         source="Per-author scoring corpus"
         agent="Bobbito"

--- a/components/OverviewFiguresClient.tsx
+++ b/components/OverviewFiguresClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import {
   Area,
   AreaChart,
@@ -32,15 +33,21 @@ export function OverviewSurfaceChart({
 }: {
   data: { platform: string; reach: number; signups: number; paid: number; consulting: number; assists: number }[];
 }) {
+  // Scope SVG gradient ids per-instance — global ids would collide if two of these
+  // chart components mounted on the same page.
+  const idBase = useId();
+  const signupsGradient = `${idBase}-signups`;
+  const reachGradient = `${idBase}-reach`;
+
   return (
     <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1} initialDimension={{ width: 640, height: 320 }}>
       <AreaChart data={data} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
         <defs>
-          <linearGradient id="cv-signups" x1="0" x2="0" y1="0" y2="1">
+          <linearGradient id={signupsGradient} x1="0" x2="0" y1="0" y2="1">
             <stop offset="5%" stopColor="#ff9d42" stopOpacity={0.45} />
             <stop offset="95%" stopColor="#ff9d42" stopOpacity={0.02} />
           </linearGradient>
-          <linearGradient id="cv-reach" x1="0" x2="0" y1="0" y2="1">
+          <linearGradient id={reachGradient} x1="0" x2="0" y1="0" y2="1">
             <stop offset="5%" stopColor="#55a7ff" stopOpacity={0.18} />
             <stop offset="95%" stopColor="#55a7ff" stopOpacity={0.02} />
           </linearGradient>
@@ -68,7 +75,7 @@ export function OverviewSurfaceChart({
           type="monotone"
           dataKey="reach"
           stroke="#55a7ff"
-          fill="url(#cv-reach)"
+          fill={`url(#${reachGradient})`}
           strokeWidth={1.6}
           isAnimationActive
           animationDuration={1200}
@@ -78,7 +85,7 @@ export function OverviewSurfaceChart({
           type="monotone"
           dataKey="signups"
           stroke="#ff9d42"
-          fill="url(#cv-signups)"
+          fill={`url(#${signupsGradient})`}
           strokeWidth={2.2}
           isAnimationActive
           animationDuration={1400}

--- a/components/OverviewFiguresClient.tsx
+++ b/components/OverviewFiguresClient.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatNumber } from "@/lib/formatters";
+
+const tooltipStyle = {
+  background: "hsl(var(--card))",
+  border: "1px solid hsl(var(--foreground) / 0.18)",
+  borderRadius: 2,
+  fontFamily: "var(--font-geist-mono), monospace",
+  fontSize: 12,
+  letterSpacing: "0.04em",
+  textTransform: "uppercase" as const,
+  padding: "8px 10px",
+};
+
+const axisTick = { fill: "hsl(var(--muted-foreground))", fontSize: 11, fontFamily: "var(--font-geist-mono)" };
+
+export function OverviewSurfaceChart({
+  data,
+}: {
+  data: { platform: string; reach: number; signups: number; paid: number; consulting: number; assists: number }[];
+}) {
+  return (
+    <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1} initialDimension={{ width: 640, height: 320 }}>
+      <AreaChart data={data} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
+        <defs>
+          <linearGradient id="cv-signups" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="5%" stopColor="#ff9d42" stopOpacity={0.45} />
+            <stop offset="95%" stopColor="#ff9d42" stopOpacity={0.02} />
+          </linearGradient>
+          <linearGradient id="cv-reach" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="5%" stopColor="#55a7ff" stopOpacity={0.18} />
+            <stop offset="95%" stopColor="#55a7ff" stopOpacity={0.02} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid stroke="hsl(var(--foreground) / 0.06)" vertical={false} />
+        <XAxis
+          dataKey="platform"
+          tick={axisTick}
+          tickLine={false}
+          axisLine={{ stroke: "hsl(var(--foreground) / 0.12)" }}
+          interval={0}
+          angle={-15}
+          height={48}
+          textAnchor="end"
+        />
+        <YAxis
+          tick={axisTick}
+          tickFormatter={formatNumber}
+          tickLine={false}
+          axisLine={false}
+          width={56}
+        />
+        <Tooltip contentStyle={tooltipStyle} cursor={{ stroke: "hsl(var(--court-line) / 0.4)", strokeWidth: 1, strokeDasharray: "2 4" }} />
+        <Area
+          type="monotone"
+          dataKey="reach"
+          stroke="#55a7ff"
+          fill="url(#cv-reach)"
+          strokeWidth={1.6}
+          isAnimationActive
+          animationDuration={1200}
+          animationEasing="ease-out"
+        />
+        <Area
+          type="monotone"
+          dataKey="signups"
+          stroke="#ff9d42"
+          fill="url(#cv-signups)"
+          strokeWidth={2.2}
+          isAnimationActive
+          animationDuration={1400}
+          animationEasing="ease-out"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function OverviewRosterChart({
+  data,
+}: {
+  data: { name: string; Trust: number; "Social TS": number; Assists: number }[];
+}) {
+  return (
+    <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1} initialDimension={{ width: 640, height: 320 }}>
+      <BarChart data={data} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+        <CartesianGrid stroke="hsl(var(--foreground) / 0.06)" vertical={false} />
+        <XAxis
+          dataKey="name"
+          tick={axisTick}
+          tickLine={false}
+          axisLine={{ stroke: "hsl(var(--foreground) / 0.12)" }}
+        />
+        <YAxis tick={axisTick} tickLine={false} axisLine={false} width={42} />
+        <Tooltip contentStyle={tooltipStyle} cursor={{ fill: "hsl(var(--court-line) / 0.05)" }} />
+        <Bar dataKey="Trust" fill="#b78cff" radius={[3, 3, 0, 0]} maxBarSize={28} isAnimationActive animationDuration={1100} />
+        <Bar dataKey="Social TS" fill="#3ee7d3" radius={[3, 3, 0, 0]} maxBarSize={28} isAnimationActive animationDuration={1100} />
+        <Bar dataKey="Assists" fill="#ff9d42" radius={[3, 3, 0, 0]} maxBarSize={28} isAnimationActive animationDuration={1100} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/components/essay/Byline.tsx
+++ b/components/essay/Byline.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+export type BylineProps = {
+  /** The person who reads/owns this essay (e.g. "Austin Tedesco · Head of Growth"). */
+  author?: string;
+  /** Always rendered as the agent who *wrote* the data narrative. */
+  agent?: string;
+  /** Free-form date string — render as the operator already formatted it. */
+  date?: string;
+  /** Issue / experiment number — Every Studio convention, e.g. "#007". */
+  issue?: string;
+  /** Filed-under label, displayed as a kicker. e.g. "EVERY COURT VISION · BRIEFING". */
+  filedUnder?: string;
+  className?: string;
+};
+
+export function Byline({ author, agent = "Bobbito", date, issue = "#007", filedUnder, className }: BylineProps) {
+  return (
+    <div className={cn("flex flex-wrap items-baseline gap-x-4 gap-y-1.5 text-caption", className)}>
+      {issue ? (
+        <span className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+          Experiment {issue}
+        </span>
+      ) : null}
+      {filedUnder ? (
+        <span className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground/80 tabular">
+          {filedUnder}
+        </span>
+      ) : null}
+      {author ? (
+        <span className="font-serif italic text-foreground/85">By {author}</span>
+      ) : null}
+      <span className="font-serif italic text-muted-foreground">
+        with <span className="text-foreground/85">{agent}</span>
+      </span>
+      {date ? (
+        <span className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+          {date}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/components/essay/Cover.tsx
+++ b/components/essay/Cover.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Eyebrow } from "./Eyebrow";
+import { EssayTitle } from "./EssayTitle";
+
+export type CoverProps = {
+  eyebrow?: string;
+  title: ReactNode;
+  /** Optional subtitle / dek line — italic serif. */
+  dek?: ReactNode;
+  /** Optional cover image URL (DALL-E/Midjourney library, per Every essay convention). */
+  imageUrl?: string;
+  /** When supplied, swap the procedural cover for an image with overlay treatment. */
+  alt?: string;
+  /** Right-side accent — e.g. issue number or status pill. */
+  accent?: ReactNode;
+  /** Slot for chips or a CTA below the title. */
+  footer?: ReactNode;
+  className?: string;
+  /**
+   * Visual variant of the procedural cover (used when no imageUrl is provided).
+   * "rays" = conic warm/cool rays, "court" = court diagram bg, "newsprint" = flat newsprint.
+   */
+  variant?: "rays" | "court" | "newsprint";
+};
+
+/**
+ * Cover — the full-bleed essay opening.
+ *
+ * Every essay convention quoted from graph/themes/every-design-system.md:41:
+ *   "Bold typography for headlines paired with high-quality illustrative cover art
+ *   (DALL-E/Midjourney/Every illustrations)."
+ *
+ * If no `imageUrl` is supplied, a procedural cover stands in — court grid + warm/cool rays —
+ * so engineering doesn't block on illustration generation.
+ */
+export function Cover({
+  eyebrow,
+  title,
+  dek,
+  imageUrl,
+  alt,
+  accent,
+  footer,
+  className,
+  variant = "rays",
+}: CoverProps) {
+  const variantClass =
+    variant === "newsprint"
+      ? "bg-court-paint bg-newsprint"
+      : variant === "court"
+        ? "bg-court-paint bg-cover-grid"
+        : "bg-cover-rays";
+
+  return (
+    <section
+      className={cn(
+        "relative isolate overflow-hidden rounded-[2px] border border-foreground/10",
+        "shadow-paper",
+        className,
+      )}
+    >
+      {imageUrl ? (
+        <div
+          className="absolute inset-0 -z-10 bg-cover bg-center"
+          style={{ backgroundImage: `url("${imageUrl}")` }}
+          role={alt ? "img" : undefined}
+          aria-label={alt}
+        />
+      ) : (
+        <div className={cn("absolute inset-0 -z-10", variantClass)} aria-hidden />
+      )}
+
+      {/* Tonal scrim — every cover keeps the title legible regardless of art. */}
+      <div
+        aria-hidden
+        className="absolute inset-0 -z-10 bg-gradient-to-tr from-black/82 via-black/60 to-black/40 mix-blend-multiply"
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 -z-10 bg-gradient-to-b from-transparent via-transparent to-background"
+      />
+
+      {/* Halftime corner light */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-32 -top-24 h-72 w-72 rounded-full bg-halftime-warm/30 blur-3xl"
+      />
+
+      <div className="relative grid gap-10 px-6 pb-12 pt-10 sm:px-10 sm:pb-16 sm:pt-14 lg:grid-cols-[1fr_auto] lg:items-end lg:gap-16 lg:px-14 lg:pb-20 lg:pt-20">
+        <div className="space-y-7 max-w-3xl">
+          {eyebrow ? <Eyebrow tone="warm">{eyebrow}</Eyebrow> : null}
+          <EssayTitle size="display" className="text-court-line">
+            {title}
+          </EssayTitle>
+          {dek ? (
+            <p className="font-serif text-lede italic text-court-line/85 max-w-2xl text-balance">
+              {dek}
+            </p>
+          ) : null}
+          {footer ? <div className="pt-2">{footer}</div> : null}
+        </div>
+
+        {accent ? <div className="self-start lg:self-end">{accent}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/components/essay/Essay.tsx
+++ b/components/essay/Essay.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Essay — the publication container.
+ *
+ * Holds a Cover (full-bleed) above a content area. Children manage their own
+ * width — Body/Lede/Pull/TLDR self-constrain to a reading column; Figure spans
+ * wider; Section provides a labeled rule-break.
+ *
+ * Quote from graph/themes/every-design-system.md:54:
+ *   "Generous whitespace with modular sections, horizontal rules for separation."
+ */
+export function Essay({
+  children,
+  cover,
+  className,
+}: {
+  children: ReactNode;
+  /** The Cover component. Rendered above the content, full-width. */
+  cover?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <article className={cn("space-y-10 lg:space-y-14", className)}>
+      {cover}
+      <div className="mx-auto w-full max-w-7xl space-y-8 px-4 sm:px-6 lg:space-y-10 lg:px-8">
+        {children}
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Section — a horizontally-ruled section break with optional eyebrow and title.
+ * Mirrors the "modular sections, horizontal rules for separation" pattern.
+ */
+export function Section({
+  children,
+  title,
+  eyebrow,
+  className,
+}: {
+  children: ReactNode;
+  title?: ReactNode;
+  eyebrow?: string;
+  className?: string;
+}) {
+  return (
+    <section className={cn("space-y-5", className)}>
+      <div className="space-y-3">
+        <div className="rule" aria-hidden />
+        {eyebrow ? (
+          <p className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+            {eyebrow}
+          </p>
+        ) : null}
+        {title ? (
+          <h2
+            className="font-serif text-figure-title leading-tight text-foreground text-balance"
+            style={{ fontVariationSettings: '"SOFT" 50, "WONK" 0, "opsz" 96' }}
+          >
+            {title}
+          </h2>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/components/essay/EssayTitle.tsx
+++ b/components/essay/EssayTitle.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function EssayTitle({
+  children,
+  className,
+  size = "essay",
+}: {
+  children: ReactNode;
+  className?: string;
+  size?: "essay" | "display" | "figure";
+}) {
+  const sizeClass = {
+    essay: "text-essay-title",
+    display: "text-display",
+    figure: "text-figure-title",
+  }[size];
+
+  return (
+    <h1
+      className={cn(
+        "font-serif text-balance leading-[1.04] text-foreground",
+        sizeClass,
+        className,
+      )}
+      style={{ fontVariationSettings: '"SOFT" 60, "WONK" 0, "opsz" 144' }}
+    >
+      {children}
+    </h1>
+  );
+}

--- a/components/essay/Eyebrow.tsx
+++ b/components/essay/Eyebrow.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function Eyebrow({
+  children,
+  className,
+  tone = "default",
+}: {
+  children: ReactNode;
+  className?: string;
+  tone?: "default" | "primary" | "warm" | "chalk";
+}) {
+  const toneClass = {
+    default: "text-muted-foreground",
+    primary: "text-primary",
+    warm: "text-court-orange",
+    chalk: "text-court-line/80",
+  }[tone];
+
+  return (
+    <p
+      className={cn(
+        "ticker tabular flex items-center gap-2 text-eyebrow",
+        toneClass,
+        className,
+      )}
+    >
+      <span aria-hidden className="inline-block h-px w-6 bg-current opacity-60" />
+      <span>{children}</span>
+    </p>
+  );
+}

--- a/components/essay/Figure.tsx
+++ b/components/essay/Figure.tsx
@@ -1,0 +1,182 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Eyebrow } from "./Eyebrow";
+import { ReadWith } from "./ReadWith";
+
+/**
+ * Figure — the data-figure primitive that turns a chart into an inline essay block.
+ *
+ * Rhythm (hex.tech-flavored, Every-typed):
+ *   FIG.NN ──── EYEBROW ─── (e.g. "THE QUESTION", "WHAT HAPPENED")
+ *                 Bold serif title
+ *                 Italic serif lede caption
+ *
+ *                 [ chart slot — generous, breathing ]
+ *
+ *                 Source · agent CTA · footnote
+ *
+ * Use this in place of plain divs around recharts/d3 figures. Each chart in an essay
+ * gets a Figure wrapper. Figure NUMBERS are stable-per-essay so prose can reference
+ * them ("see Fig. 02").
+ */
+export function Figure({
+  number,
+  eyebrow,
+  title,
+  caption,
+  source,
+  agent,
+  agentPrompt,
+  ledeRight,
+  children,
+  className,
+  bleed = false,
+  surface = "card",
+}: {
+  /** Figure number — e.g. "01", "02". Pads to 2 digits visually. */
+  number?: string | number;
+  /** Tiny uppercase label above the title. e.g. "THE QUESTION", "WHAT HAPPENED". */
+  eyebrow?: string;
+  /** Bold serif figure title. */
+  title: ReactNode;
+  /** Italic serif lede caption — explains in 1–2 sentences what to look at. */
+  caption?: ReactNode;
+  /** Tiny right-side note next to the eyebrow — typically the data source or window. */
+  ledeRight?: ReactNode;
+  /** Source line shown at the figure foot. */
+  source?: string;
+  /** Agent name for the Read-with CTA. Defaults to Bobbito. */
+  agent?: string;
+  /** Optional prompt that the agent CTA fires. */
+  agentPrompt?: string;
+  /** The chart itself. */
+  children: ReactNode;
+  className?: string;
+  /** When true, the chart bleeds edge-to-edge inside the figure (no inner padding). */
+  bleed?: boolean;
+  /** "card" = subtle bordered card, "naked" = no border, "court" = dark canvas (use for telestrator). */
+  surface?: "card" | "naked" | "court";
+}) {
+  const num = number ? String(number).padStart(2, "0") : undefined;
+
+  const surfaceClass = {
+    card: "rounded-sm border border-foreground/10 bg-card/40 shadow-[0_30px_120px_-50px_rgba(0,0,0,0.6)]",
+    naked: "",
+    court: "rounded-sm border border-court-line/20 bg-[radial-gradient(circle_at_30%_-20%,rgba(255,157,66,0.06),transparent_55%),radial-gradient(circle_at_75%_120%,rgba(85,167,255,0.05),transparent_60%),hsl(var(--court-paint))] shadow-[0_40px_160px_-60px_rgba(0,0,0,0.7)]",
+  }[surface];
+
+  return (
+    <figure
+      className={cn(
+        "group/figure relative my-8",
+        // Wide essays get an outdent so figures can breathe past the prose column.
+        "lg:-mx-2",
+        className,
+      )}
+    >
+      {/* Figure header — typographic rhythm before the chart. */}
+      <header className="mb-5 flex flex-col gap-2 px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          {num ? (
+            <span className="font-mono text-eyebrow uppercase tracking-ticker text-court-orange tabular">
+              Fig. {num}
+            </span>
+          ) : null}
+          {eyebrow ? <Eyebrow tone={num ? "default" : "primary"}>{eyebrow}</Eyebrow> : null}
+          {ledeRight ? (
+            <span className="ml-auto font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+              {ledeRight}
+            </span>
+          ) : null}
+        </div>
+        <h3
+          className="font-serif text-figure-title leading-[1.18] text-foreground text-balance"
+          style={{ fontVariationSettings: '"SOFT" 50, "WONK" 0, "opsz" 96' }}
+        >
+          {title}
+        </h3>
+        {caption ? (
+          <p className="font-serif italic text-caption text-muted-foreground max-w-2xl text-balance">
+            {caption}
+          </p>
+        ) : null}
+      </header>
+
+      {/* Chart surface */}
+      <div
+        className={cn(
+          surfaceClass,
+          bleed ? "" : "p-4 sm:p-6 lg:p-8",
+          "relative overflow-hidden",
+        )}
+      >
+        {children}
+      </div>
+
+      {/* Footer: source + agent CTA */}
+      {(source || agent !== undefined || agentPrompt) ? (
+        <figcaption className="mt-3 flex flex-wrap items-baseline justify-between gap-3 px-4 sm:px-6 lg:px-8">
+          {source ? (
+            <span className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground/80 tabular">
+              Source · {source}
+            </span>
+          ) : (
+            <span />
+          )}
+          <ReadWith agent={agent} prompt={agentPrompt}>
+            Read this figure with
+          </ReadWith>
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+/**
+ * StatTile — the hex.tech-flavored count-up stat block. Used inside an Essay for
+ * single-number callouts (the "scoreboard" inside a paragraph).
+ */
+export function StatTile({
+  label,
+  value,
+  detail,
+  trend,
+  className,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  trend?: "up" | "down" | "flat";
+  className?: string;
+}) {
+  const arrow = trend === "up" ? "▲" : trend === "down" ? "▼" : trend === "flat" ? "—" : null;
+  const arrowColor = trend === "up" ? "text-confidence-direct" : trend === "down" ? "text-court-red" : "text-muted-foreground";
+
+  return (
+    <div
+      className={cn(
+        "group/stat relative isolate flex flex-col justify-between gap-3 overflow-hidden rounded-sm border border-foreground/10 bg-card/30 p-5",
+        "transition-colors hover:border-court-orange/40",
+        className,
+      )}
+    >
+      <span aria-hidden className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-court-orange/40 to-transparent opacity-0 transition-opacity group-hover/stat:opacity-100" />
+      <span className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular">
+        {label}
+      </span>
+      <div className="font-mono text-stat-lg leading-none tabular text-foreground animate-count">
+        {value}
+      </div>
+      {(detail || arrow) ? (
+        <div className="flex items-baseline gap-2 text-caption">
+          {arrow ? <span className={cn("font-mono tabular", arrowColor)}>{arrow}</span> : null}
+          {detail ? (
+            <span className="font-serif italic text-muted-foreground">{detail}</span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/essay/Figure.tsx
+++ b/components/essay/Figure.tsx
@@ -115,7 +115,9 @@ export function Figure({
         {children}
       </div>
 
-      {/* Footer: source + agent CTA */}
+      {/* Footer: source line and/or agent CTA. The agent CTA only renders when the
+          caller explicitly opts in via `agent` or `agentPrompt` — so a source-only
+          figure stays source-only and doesn't auto-pick up a Bobbito link. */}
       {(source || agent !== undefined || agentPrompt) ? (
         <figcaption className="mt-3 flex flex-wrap items-baseline justify-between gap-3 px-4 sm:px-6 lg:px-8">
           {source ? (
@@ -125,9 +127,11 @@ export function Figure({
           ) : (
             <span />
           )}
-          <ReadWith agent={agent} prompt={agentPrompt}>
-            Read this figure with
-          </ReadWith>
+          {agent !== undefined || agentPrompt ? (
+            <ReadWith agent={agent} prompt={agentPrompt}>
+              Read this figure with
+            </ReadWith>
+          ) : null}
         </figcaption>
       ) : null}
     </figure>

--- a/components/essay/FourTierFeedback.tsx
+++ b/components/essay/FourTierFeedback.tsx
@@ -17,8 +17,16 @@ const tiers = [
  * Quote from graph/themes/every-design-system.md:62:
  *   "Four-tier feedback rating system: Amazing, Good, Meh, Bad"
  *
- * Lives at the bottom of every Court Vision essay. Stateless on the wire (we just
- * post a rating); local state shows a confirmed checkmark.
+ * Lives at the bottom of every Court Vision essay. Currently stateless — clicking
+ * a tier stores the choice in local React state and fires the optional `onRate`
+ * callback, but no server persistence is wired up yet. Phase 4 of the brand-wrap
+ * plan adds the rating endpoint and per-essay aggregation. Until then, callers
+ * that want to capture ratings can pass `onRate` and forward to their own
+ * analytics sink.
+ *
+ * TODO(brand-wrap-plan-phase-4): persist ratings to /api/feedback once the
+ *   feedback collection endpoint ships, and surface period-level aggregates back
+ *   in the next briefing essay.
  */
 export function FourTierFeedback({
   prompt = "What did you think?",

--- a/components/essay/FourTierFeedback.tsx
+++ b/components/essay/FourTierFeedback.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const tiers = [
+  { label: "Amazing", glyph: "◆", tone: "text-confidence-direct" },
+  { label: "Good", glyph: "●", tone: "text-court-teal" },
+  { label: "Meh", glyph: "○", tone: "text-court-line" },
+  { label: "Bad", glyph: "✕", tone: "text-court-red" },
+] as const;
+
+/**
+ * FourTierFeedback — the "What did you think?" rating row.
+ *
+ * Quote from graph/themes/every-design-system.md:62:
+ *   "Four-tier feedback rating system: Amazing, Good, Meh, Bad"
+ *
+ * Lives at the bottom of every Court Vision essay. Stateless on the wire (we just
+ * post a rating); local state shows a confirmed checkmark.
+ */
+export function FourTierFeedback({
+  prompt = "What did you think?",
+  className,
+  onRate,
+}: {
+  prompt?: string;
+  className?: string;
+  onRate?: (rating: (typeof tiers)[number]["label"]) => void;
+}) {
+  const [chosen, setChosen] = useState<string | null>(null);
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4 border-t border-foreground/15 pt-6 sm:flex-row sm:items-center sm:justify-between",
+        className,
+      )}
+      aria-label="Reader feedback"
+    >
+      <p className="font-serif italic text-caption text-muted-foreground">{prompt}</p>
+      <div className="flex flex-wrap gap-2">
+        {tiers.map((tier) => {
+          const selected = chosen === tier.label;
+          return (
+            <button
+              key={tier.label}
+              type="button"
+              onClick={() => {
+                setChosen(tier.label);
+                onRate?.(tier.label);
+              }}
+              aria-pressed={selected}
+              className={cn(
+                "group inline-flex items-center gap-2 rounded-full border px-3.5 py-1.5",
+                "font-mono text-eyebrow uppercase tracking-ticker tabular transition",
+                "border-foreground/15 bg-card/30 text-foreground/75 hover:border-foreground/35 hover:text-foreground",
+                selected && "border-primary/60 bg-primary/10 text-foreground shadow-glow",
+              )}
+            >
+              <span aria-hidden className={cn("text-[0.95em] leading-none", tier.tone)}>
+                {tier.glyph}
+              </span>
+              <span>{tier.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/essay/Lede.tsx
+++ b/components/essay/Lede.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Lede — the opening paragraph.
+ *
+ * Optional drop-cap on the first letter (Every essay convention). Use sparingly —
+ * one drop-cap per essay max. After the lede, regular <Body /> paragraphs follow.
+ */
+export function Lede({
+  children,
+  dropCap = false,
+  className,
+}: {
+  children: ReactNode;
+  dropCap?: boolean;
+  className?: string;
+}) {
+  return (
+    <p
+      className={cn(
+        "font-serif text-lede leading-[1.45] text-foreground/92 max-w-3xl text-balance",
+        dropCap && "drop-cap",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Body — a regular essay paragraph. Distinct from <p> so we can scope reading-first
+ * type tokens without leaking into the rest of the app.
+ */
+export function Body({
+  children,
+  className,
+  asides,
+}: {
+  children: ReactNode;
+  className?: string;
+  /** Optional sidenote rendered to the right on wide screens, inline above on mobile. */
+  asides?: ReactNode;
+}) {
+  if (asides) {
+    return (
+      <div className={cn("grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(180px,18ch)] lg:gap-10", className)}>
+        <p className="font-serif text-body leading-[1.68] text-foreground/88 max-w-3xl">
+          {children}
+        </p>
+        <aside className="font-mono text-eyebrow uppercase tracking-ticker text-muted-foreground tabular border-l border-foreground/15 pl-4 lg:mt-2">
+          {asides}
+        </aside>
+      </div>
+    );
+  }
+  return (
+    <p
+      className={cn(
+        "font-serif text-body leading-[1.68] text-foreground/88 max-w-3xl",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Pull — the magazine-style pull quote. Big, indented, italic Fraunces.
+ */
+export function Pull({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <figure className={cn("my-8 max-w-3xl", className)}>
+      <blockquote
+        className="font-serif italic text-foreground/95 leading-[1.18] text-balance"
+        style={{
+          fontVariationSettings: '"SOFT" 100, "WONK" 0, "opsz" 144',
+          fontSize: "1.875rem",
+        }}
+      >
+        <span className="select-none pr-1 text-court-orange opacity-80" aria-hidden>
+          “
+        </span>
+        {children}
+        <span className="select-none pl-1 text-court-orange opacity-80" aria-hidden>
+          ”
+        </span>
+      </blockquote>
+    </figure>
+  );
+}

--- a/components/essay/ReadWith.tsx
+++ b/components/essay/ReadWith.tsx
@@ -1,0 +1,48 @@
+import { Sparkles } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * ReadWith — the inline "Read with [agent]" CTA.
+ *
+ * Quote from graph/themes/every-design-system.md:63:
+ *   "'Read with AI' and 'Open with Plus One' interactive AI collaboration buttons"
+ *
+ * Quote from graph/themes/every-design-system.md:292:
+ *   "Humanization pattern: Named AI agents (R2-C2, Iris, Montaigne, Margot, Alfredo,
+ *   Milo, Nettle) with assigned managers"
+ *
+ * Court Vision's analyst agent — peer of Iris/Montaigne — is named **Bobbito**, the
+ * single explicit NBA Street Vol. 2 nod (the announcer who reads the film with you).
+ */
+export function ReadWith({
+  agent = "Bobbito",
+  prompt,
+  className,
+  children,
+}: {
+  agent?: string;
+  prompt?: string;
+  className?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <a
+      href={prompt ? `/api/agent?prompt=${encodeURIComponent(prompt)}&agent=${encodeURIComponent(agent)}` : "#"}
+      className={cn(
+        "group inline-flex items-baseline gap-2 font-serif text-caption italic text-foreground/80",
+        "reveal-underline focus-visible:outline-none focus-visible:text-primary",
+        className,
+      )}
+    >
+      <Sparkles aria-hidden className="size-[0.85em] -translate-y-px text-primary" />
+      <span>
+        {children ?? "Read with"} <span className="not-italic font-medium text-foreground">{agent}</span>
+      </span>
+      <span aria-hidden className="text-primary transition-transform group-hover:translate-x-0.5">
+        →
+      </span>
+    </a>
+  );
+}

--- a/components/essay/TLDR.tsx
+++ b/components/essay/TLDR.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * TLDR — the article-start summary box.
+ *
+ * Quote from graph/themes/every-design-system.md:62:
+ *   "TLDR (Too Long; Didn't Read) summary boxes at article start"
+ *
+ * Renders as a bordered box with a serif label, a tight rule, and 2–4 bullet
+ * sentences as the actual takeaway. Used at the top of every Court Vision essay,
+ * directly under Byline.
+ */
+export function TLDR({
+  bullets,
+  label = "TL;DR",
+  className,
+}: {
+  bullets: ReactNode[];
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <aside
+      className={cn(
+        "relative grid gap-4 rounded-sm border border-foreground/15 bg-card/40 p-6 sm:grid-cols-[auto_1fr] sm:gap-8 sm:p-7",
+        "shadow-[0_1px_0_hsl(var(--foreground)/0.04)]",
+        className,
+      )}
+      aria-label="Summary"
+    >
+      <div className="flex items-center gap-3 sm:flex-col sm:items-start sm:gap-2">
+        <span className="font-mono text-eyebrow uppercase tracking-ticker text-court-orange tabular">
+          {label}
+        </span>
+        <span aria-hidden className="hidden h-px w-10 bg-court-orange/60 sm:inline-block" />
+        <span aria-hidden className="inline-block h-3 w-px bg-court-orange/60 sm:hidden" />
+      </div>
+      <ul className="font-serif text-body space-y-2.5 text-foreground/90">
+        {bullets.map((bullet, idx) => (
+          <li key={idx} className="flex gap-3">
+            <span
+              aria-hidden
+              className="mt-[0.85em] inline-block h-px w-3 shrink-0 bg-foreground/40"
+            />
+            <span className="text-balance">{bullet}</span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/components/essay/index.ts
+++ b/components/essay/index.ts
@@ -1,0 +1,12 @@
+export { Byline } from "./Byline";
+export type { BylineProps } from "./Byline";
+export { Cover } from "./Cover";
+export type { CoverProps } from "./Cover";
+export { Essay, Section } from "./Essay";
+export { EssayTitle } from "./EssayTitle";
+export { Eyebrow } from "./Eyebrow";
+export { Figure, StatTile } from "./Figure";
+export { FourTierFeedback } from "./FourTierFeedback";
+export { Body, Lede, Pull } from "./Lede";
+export { ReadWith } from "./ReadWith";
+export { TLDR } from "./TLDR";

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -383,23 +383,50 @@ export async function getPosts(filters: FilterState): Promise<PostWithEmployee[]
 }
 
 /**
- * Fetch ripple events scoped to the post set produced by `filters`.
+ * Fetch every ripple event, unscoped. Cheap, indexed query — callers that need
+ * scoping should pair this with `getPosts(filters)` in `Promise.all`, then call
+ * `scopeRippleEventsToPosts(events, posts)` to filter in memory. This split keeps
+ * the ripple DB query running concurrently with the post query rather than
+ * serializing behind it.
+ */
+export async function getAllRippleEvents(): Promise<RippleEvent[]> {
+  const events = await db.rippleEvent.findMany({ orderBy: { occurredAt: "asc" } });
+  return events.map(mapRippleEvent);
+}
+
+/**
+ * In-memory filter: keep only ripple events whose `rootPostId` is present in the
+ * provided post set. Pure function — no I/O. Pair with `getAllRippleEvents`.
+ */
+export function scopeRippleEventsToPosts(
+  events: RippleEvent[],
+  posts: { id: string }[],
+): RippleEvent[] {
+  const postIds = new Set(posts.map((post) => post.id));
+  return events.filter((event) => postIds.has(event.rootPostId));
+}
+
+/**
+ * Convenience: fetch ripple events scoped to the post set produced by `filters`.
  *
  * When the caller has already loaded the filtered posts (e.g. on /overview or
- * /shot-plot which need both posts and ripples), pass them in via `prefetchedPosts`
- * to skip a second `getPosts(filters)` round-trip. Callers that only need ripples
- * (e.g. /stream) can omit it and the function falls back to fetching internally.
+ * /shot-plot which need both), pass them in via `prefetchedPosts` to skip a
+ * second `getPosts(filters)` round-trip. Callers that only need ripples (e.g.
+ * /stream) can omit it.
+ *
+ * For maximum parallelism, prefer the lower-level `getAllRippleEvents` +
+ * `scopeRippleEventsToPosts` pair so the ripple DB query runs in `Promise.all`
+ * alongside the post query rather than serially after it.
  */
 export async function getRippleEvents(
   filters: FilterState,
   prefetchedPosts?: PostWithEmployee[],
 ): Promise<RippleEvent[]> {
   const [events, posts] = await Promise.all([
-    db.rippleEvent.findMany({ orderBy: { occurredAt: "asc" } }),
+    getAllRippleEvents(),
     prefetchedPosts ? Promise.resolve(prefetchedPosts) : getPosts(filters),
   ]);
-  const postIds = new Set(posts.map((post) => post.id));
-  return events.filter((event) => postIds.has(event.rootPostId)).map(mapRippleEvent);
+  return scopeRippleEventsToPosts(events, posts);
 }
 
 export async function getPlays(): Promise<Play[]> {

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -382,10 +382,21 @@ export async function getPosts(filters: FilterState): Promise<PostWithEmployee[]
   return filterPosts(posts.map(mapPost), filters);
 }
 
-export async function getRippleEvents(filters: FilterState): Promise<RippleEvent[]> {
+/**
+ * Fetch ripple events scoped to the post set produced by `filters`.
+ *
+ * When the caller has already loaded the filtered posts (e.g. on /overview or
+ * /shot-plot which need both posts and ripples), pass them in via `prefetchedPosts`
+ * to skip a second `getPosts(filters)` round-trip. Callers that only need ripples
+ * (e.g. /stream) can omit it and the function falls back to fetching internally.
+ */
+export async function getRippleEvents(
+  filters: FilterState,
+  prefetchedPosts?: PostWithEmployee[],
+): Promise<RippleEvent[]> {
   const [events, posts] = await Promise.all([
     db.rippleEvent.findMany({ orderBy: { occurredAt: "asc" } }),
-    getPosts(filters),
+    prefetchedPosts ? Promise.resolve(prefetchedPosts) : getPosts(filters),
   ]);
   const postIds = new Set(posts.map((post) => post.id));
   return events.filter((event) => postIds.has(event.rootPostId)).map(mapRippleEvent);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,17 +49,22 @@ const config: Config = {
           rule: "hsl(var(--paper-rule))",
         },
 
-        // Court canvas (sacred — basketball metaphor preserved)
+        // Court canvas (sacred — basketball metaphor preserved). The saturated values
+        // are defined ONCE in globals.css as `--court-{line,wood,paint,teal,…}`; we
+        // reference them here through `hsl(var(--…) / <alpha-value>)` so Tailwind
+        // utilities (`fill-court-line`, `bg-court-orange/40`) and SVG inline styles
+        // (`hsl(var(--court-line) / 0.4)`) agree on a single source of truth.
         court: {
-          line: "#f2d2a5",
-          wood: "#281b15",
-          paint: "#172136",
-          teal: "#3ee7d3",
-          orange: "#ff9d42",
-          purple: "#b78cff",
-          red: "#ff5a66",
-          blue: "#55a7ff",
-          // Chrome-safe muted variants — desat 40%, lighten 15% — for use outside the canvas.
+          line: "hsl(var(--court-line) / <alpha-value>)",
+          wood: "hsl(var(--court-wood) / <alpha-value>)",
+          paint: "hsl(var(--court-paint) / <alpha-value>)",
+          teal: "hsl(var(--court-teal) / <alpha-value>)",
+          orange: "hsl(var(--court-orange) / <alpha-value>)",
+          purple: "hsl(var(--court-purple) / <alpha-value>)",
+          red: "hsl(var(--court-red) / <alpha-value>)",
+          blue: "hsl(var(--court-blue) / <alpha-value>)",
+          // Chrome-safe muted variants — desat 40%, lighten 15% — for use outside the
+          // SVG canvas. Hex-only because they don't need to mix with inline SVG styles.
           "muted-teal": "#7ec8bd",
           "muted-orange": "#c98c5a",
           "muted-purple": "#9784b8",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,18 +17,39 @@ const config: Config = {
         "card-foreground": "hsl(var(--card-foreground))",
         popover: "hsl(var(--popover))",
         "popover-foreground": "hsl(var(--popover-foreground))",
-        primary: "hsl(var(--primary))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        // Backwards-compat for shadcn primitives that read these as flat tokens.
         "primary-foreground": "hsl(var(--primary-foreground))",
-        secondary: "hsl(var(--secondary))",
         "secondary-foreground": "hsl(var(--secondary-foreground))",
-        muted: "hsl(var(--muted))",
         "muted-foreground": "hsl(var(--muted-foreground))",
-        accent: "hsl(var(--accent))",
         "accent-foreground": "hsl(var(--accent-foreground))",
         destructive: "hsl(var(--destructive))",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
+
+        paper: {
+          DEFAULT: "hsl(var(--paper))",
+          foreground: "hsl(var(--paper-foreground))",
+          rule: "hsl(var(--paper-rule))",
+        },
+
+        // Court canvas (sacred — basketball metaphor preserved)
         court: {
           line: "#f2d2a5",
           wood: "#281b15",
@@ -38,15 +59,106 @@ const config: Config = {
           purple: "#b78cff",
           red: "#ff5a66",
           blue: "#55a7ff",
+          // Chrome-safe muted variants — desat 40%, lighten 15% — for use outside the canvas.
+          "muted-teal": "#7ec8bd",
+          "muted-orange": "#c98c5a",
+          "muted-purple": "#9784b8",
+          "muted-red": "#b8767c",
+          "muted-blue": "#6f8db0",
+        },
+
+        // Proof-style provenance rails. Quote: "Provenance Rail: Left-side UI component
+        // using color (green/purple) to track text origin" — every-design-system.md:254
+        confidence: {
+          direct: "hsl(var(--confidence-direct))",
+          strong: "hsl(var(--confidence-strong))",
+          inferred: "hsl(var(--confidence-inferred))",
+          needs: "hsl(var(--confidence-needs))",
+          neutral: "hsl(var(--confidence-neutral))",
+        },
+
+        halftime: {
+          warm: "hsl(var(--halftime-warm))",
+          cool: "hsl(var(--halftime-cool))",
         },
       },
+
       fontFamily: {
-        sans: ["var(--font-geist-sans)", "Inter", "system-ui", "sans-serif"],
-        mono: ["var(--font-geist-mono)", "SFMono-Regular", "monospace"],
+        // Editorial display + body — Fraunces (variable, SOFT axis) does both.
+        serif: ["var(--font-fraunces)", "Iowan Old Style", "Georgia", "serif"],
+        // UI chrome (nav, buttons, tables, controls).
+        sans: ["var(--font-geist-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
+        // Stats, ticker, code.
+        mono: ["var(--font-geist-mono)", "SFMono-Regular", "ui-monospace", "monospace"],
+        // Telestrator chalk annotations.
+        chalk: ["var(--font-chalk)", "Marker Felt", "cursive"],
+        // NBA Street GameBreaker overlays only.
+        gamebreaker: ["var(--font-gamebreaker)", "Impact", "sans-serif"],
       },
+
+      // Editorial type scale — every Figure has eyebrow → title → lede → chart → caption rhythm.
+      fontSize: {
+        eyebrow: ["0.6875rem", { lineHeight: "1.15", letterSpacing: "0.22em", fontWeight: "500" }],
+        caption: ["0.8125rem", { lineHeight: "1.55", letterSpacing: "0.005em" }],
+        body: ["1.0625rem", { lineHeight: "1.68", letterSpacing: "-0.005em" }],
+        lede: ["1.375rem", { lineHeight: "1.45", letterSpacing: "-0.01em", fontWeight: "400" }],
+        "figure-title": ["1.5rem", { lineHeight: "1.18", letterSpacing: "-0.02em", fontWeight: "600" }],
+        "essay-title": ["3rem", { lineHeight: "1.04", letterSpacing: "-0.025em", fontWeight: "600" }],
+        display: ["clamp(3.25rem, 6vw + 1rem, 5.5rem)", { lineHeight: "0.96", letterSpacing: "-0.035em", fontWeight: "700" }],
+        "stat-xl": ["3.75rem", { lineHeight: "0.95", letterSpacing: "-0.03em", fontWeight: "600" }],
+        "stat-lg": ["2.5rem", { lineHeight: "1.0", letterSpacing: "-0.02em", fontWeight: "600" }],
+      },
+
+      letterSpacing: {
+        ticker: "0.22em",
+        "ticker-tight": "0.14em",
+      },
+
       boxShadow: {
-        glow: "0 0 24px rgba(62, 231, 211, 0.18)",
-        "orange-glow": "0 0 24px rgba(255, 157, 66, 0.2)",
+        glow: "0 0 30px hsl(var(--primary) / 0.22)",
+        "orange-glow": "0 0 30px hsl(var(--court-orange) / 0.24)",
+        chalk: "0 0 12px rgba(242, 210, 165, 0.18)",
+        paper:
+          "0 1px 0 hsl(var(--paper-rule) / 0.5), 0 40px 120px -30px rgba(0,0,0,0.55), 0 8px 30px -10px rgba(0,0,0,0.4)",
+      },
+
+      backgroundImage: {
+        "cover-grid":
+          "linear-gradient(transparent 95%, hsl(var(--court-line) / 0.18) 95%), linear-gradient(90deg, transparent 95%, hsl(var(--court-line) / 0.14) 95%)",
+        "cover-rays":
+          "conic-gradient(from 220deg at 65% 40%, hsl(var(--halftime-warm) / 0.22) 0deg, hsl(var(--court-paint)) 45deg, hsl(var(--court-wood)) 130deg, hsl(var(--halftime-cool) / 0.18) 220deg, hsl(var(--court-paint)) 320deg, hsl(var(--halftime-warm) / 0.22) 360deg)",
+        newsprint: "radial-gradient(rgba(0,0,0,0.06) 1px, transparent 1px)",
+      },
+
+      backgroundSize: {
+        "cover-grid": "44px 44px",
+        newsprint: "3px 3px",
+      },
+
+      animation: {
+        "draw-in": "draw-in 1.4s cubic-bezier(0.65, 0, 0.35, 1) forwards",
+        drift: "drift 9s ease-in-out infinite",
+        hologram: "hologram 3.4s linear infinite",
+        count: "count-rise 700ms cubic-bezier(0.2, 0.7, 0.1, 1) both",
+      },
+
+      keyframes: {
+        "draw-in": {
+          from: { strokeDashoffset: "var(--length, 200)" },
+          to: { strokeDashoffset: "0" },
+        },
+        drift: {
+          "0%, 100%": { transform: "translate3d(0,0,0)" },
+          "50%": { transform: "translate3d(0,-6px,0)" },
+        },
+        hologram: {
+          "0%": { backgroundPosition: "0% 50%" },
+          "100%": { backgroundPosition: "200% 50%" },
+        },
+        "count-rise": {
+          from: { opacity: "0", transform: "translateY(8%)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Wraps Every Court Vision in an Every-publication editorial system. The basketball metaphor and the saturated `court.*` canvas palette stay sacred; everything else — typography, page furniture, navigation, data figures — becomes recognizably Every-family. `/overview` is now a generated essay, not a dashboard grid.

## Aesthetic spine (decided in product brainstorm — sparring transcript on file)

| Layer | Source | Where it lives |
|---|---|---|
| Spine | **every.to** publication grammar | Cover, Byline, TLDR, Lede with drop-cap, Body, Pull, Section, FourTierFeedback. Each figure carries a Read-with-Bobbito CTA. |
| Operating mode | **ESPN broadcast** | CourtTelestrator's chalk lines + halftime-show scrubber + ticker chrome on figure heads. |
| Celebration layer | **NBA Street Vol. 2 GameBreakers** | Three escalating tiers (GB1/GB2/GB3) — holographic edge + screen-shake + spray-paint Anton. Default state is calm. |
| Data-figure rhythm | **hex.tech** | Eyebrow → bold serif title → italic lede caption → chart → Read-with CTA. Tabular numerals on every stat; count-up animation on tile mount. |

The single named analyst agent — peer of Iris/Montaigne in [Plus One's pattern](https://every.to/on-every/introducing-plus-one-one-click-openclaw-agents-by-every) — is **Bobbito**, the only explicit NBA Street Vol. 2 nod.

## Tokens (`app/globals.css`, `tailwind.config.ts`, `app/layout.tsx`)

- **Fraunces** (variable, with the SOFT axis pushed up for warmth) loaded as editorial display + body serif. Geist sans/mono kept for UI / tabular stats. Permanent Marker for chalk; Anton for GameBreaker only.
- Editorial type scale: `eyebrow / caption / body / lede / figure-title / essay-title / display / stat-xl / stat-lg`.
- Light **paper** mode tokens for nested essay surfaces inside the default dark film-room canvas (Court Vision is dark by default — film rooms are dark).
- Proof-style provenance rails as `confidence.{direct, strong, inferred, needs, neutral}`. Borrowed verbatim from Every's design audit (`graph/themes/every-design-system.md:254`).
- `court.muted.*` (desat 40%, lighten 15%) for chrome; the saturated `court.*` palette stays canvas-only.
- Custom keyframes: `draw-in` (chalk strokes), `drift` (halftime light), `hologram` (GameBreaker), `count-rise` (StatTile mount). Custom shadows: `paper`, `glow`, `chalk`. Custom backgrounds: `cover-rays`, `cover-grid`, `newsprint`.

## New essay primitive — `components/essay/`

Modular, composable. Each piece does one thing:

- `Byline` · `Cover` · `Essay` (container) · `EssayTitle` · `Eyebrow`
- `Figure` + `StatTile` — the hex.tech-flavored data wrapper. Three surface variants: `card`, `naked`, `court`.
- `FourTierFeedback` — Amazing/Good/Meh/Bad row at the bottom of every essay (Every convention).
- `Lede` (with `Body`, `Pull`) — Body supports inline sidenotes on wide screens.
- `ReadWith` — inline "Read with Bobbito" CTA per figure.
- `TLDR` — the article-start summary box.
- `Section` — horizontal-rule section break with eyebrow + serif title.

Citations to `graph/themes/every-design-system.md` are inline in the component files as design rationale (TLDR pattern, Briefing Pattern, Provenance Rail, named-agent humanization, four-tier feedback).

## CourtTelestrator (`components/CourtTelestrator.tsx`) — the centerpiece

ESPN chalk telestrator drawn directly on the court. **Collapses Court Heat + Shot Plot + Ripple Graph + Stream into one performing surface.** Auto-focuses the highest-ripple-value root post; chalk arcs draw in with stagger; halftime-show scrubber lets the reader replay the chain event-by-event with chapter markers. Rare `GameBreakerOverlay` (holographic edge + screen-shake + spray-paint Anton) fires only when caller passes `gamebreakerLevel > 0`.

## `/overview` — canonical "publication, not dashboard" example

Cover → Byline → TLDR (4 data-derived bullets) → drop-cap'd Lede → Body → **Fig. 01** StatTile grid (count-up) → Body with sidenote → **Fig. 02 + 02b** surface flow + roster intelligence (new `OverviewFigures` + `OverviewFiguresClient`) → Body → **Fig. 03** the CourtTelestrator centerpiece (`surface="court"`, `bleed`) → Pull quote ("this is not a leaderboard" cultural rule) → Body → Section "Platform mix" → Section "What we're watching" → FourTierFeedback.

Existing components (PlatformCard, the AppShell nav, MetricCard, ProgressLine, etc.) are untouched — they fall under the brand-wrap plan's Phase 3 component refactor pass that's still ahead.

## Out of scope (deliberate)

- AppShell nav polish, CompanyHeader as Studio experiment card, AttributionBadge with provenance rail, PlayerCard as author-card, SidePanel as long-form editorial — all listed in the approved [brand-wrap plan](https://github.com/keeganmoody33/every-court-vision) under Phase 3 / 6.
- Logo lockup defaults to typeset wordmark, not SVG (operator-facing risk to ship Every's logo without permission).
- Live every.to scrape (Phase 0 of the plan) — deferred. Tokens here use Fraunces as a faithful Every-register stand-in until the operator runs the real-browser scrape to recover their actual font family.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean (Next.js 16 Turbopack, all routes regenerate)
- [x] Visual QA: spin up dev server, confirm `/overview` reads as a publication and not a dashboard
- [x] Telestrator hover/scrub/focus behavior on `/overview` Fig. 03
- [x] Compare side-by-side with `every.to/studio` — does `/overview` Cover read as experiment #007?
- [x] Drop-cap renders Fraunces correctly across browsers
- [x] Other routes (`/court-heat`, `/shot-plot`, `/players`, etc.) still render — they inherit the new tokens but haven't been refactored yet (Phase 3 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keeganmoody33/every-court-vision/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
